### PR TITLE
[NAE-1455] Navigation menu closes on small screens and cannot be reopened

### DIFF
--- a/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.spec.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.spec.ts
@@ -70,7 +70,7 @@ describe('AbstractNavigationDrawerComponent', () => {
         });
     });
 
-    it('should close',  (done) => {
+    it('should close', (done) => {
         component.close().then(res  => {
             expect(res).toEqual('close');
             done();
@@ -78,7 +78,6 @@ describe('AbstractNavigationDrawerComponent', () => {
     });
 
     it('should toggle', (done) => {
-        component.toggle();
         component.toggle().then(res  => {
             expect(res).toEqual('open');
             done();

--- a/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.spec.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.spec.ts
@@ -70,15 +70,18 @@ describe('AbstractNavigationDrawerComponent', () => {
         });
     });
 
-    it('should close', async () => {
-        await component.close().then(res  => {
-            expect(res).toEqual('open');
+    it('should close',  (done) => {
+        component.close().then(res  => {
+            expect(res).toEqual('close');
+            done();
         });
     });
 
-    it('should toggle', async () => {
-        await component.toggle().then(res  => {
+    it('should toggle', (done) => {
+        component.toggle();
+        component.toggle().then(res  => {
             expect(res).toEqual('open');
+            done();
         });
     });
 

--- a/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.ts
@@ -109,10 +109,10 @@ export abstract class AbstractNavigationDrawerComponent implements OnInit, After
     }
 
     toggle(): Promise<MatDrawerToggleResult> {
-        if (this._fixed && this._sideNav.opened) {
-            return Promise.resolve('open');
+        if (!this._sideNav.opened) {
+            this._sideNav.toggle();
         }
-        return this._sideNav.toggle();
+        return Promise.resolve('open');
     }
 
     private resolveLayout(bool: boolean): void {

--- a/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.ts
@@ -33,7 +33,7 @@ export abstract class AbstractNavigationDrawerComponent implements OnInit, After
 
     protected _config = {
         mode: 'over',
-        opened: false,
+        opened: true,
         disableClose: false
     };
 
@@ -122,7 +122,7 @@ export abstract class AbstractNavigationDrawerComponent implements OnInit, After
             disableClose: true
         } : {
             mode: 'over',
-            opened: true,
+            opened: false,
             disableClose: false
         };
         if (bool && this._sideNav) {

--- a/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.ts
@@ -109,10 +109,10 @@ export abstract class AbstractNavigationDrawerComponent implements OnInit, After
     }
 
     toggle(): Promise<MatDrawerToggleResult> {
-        if (!this._sideNav.opened) {
-            this._sideNav.toggle();
+        if (this._fixed) {
+            return Promise.resolve('open');
         }
-        return Promise.resolve('open');
+        return this._sideNav.toggle();
     }
 
     private resolveLayout(bool: boolean): void {

--- a/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/navigation-drawer/abstract-navigation-drawer.component.ts
@@ -95,21 +95,21 @@ export abstract class AbstractNavigationDrawerComponent implements OnInit, After
     }
 
     open(): Promise<MatDrawerToggleResult> {
-        if (this._fixed) {
-            return Promise.resolve('open');
+        if (!this._sideNav.opened) {
+            this._sideNav.open();
         }
-        return this._sideNav.open();
+        return Promise.resolve('open');
     }
 
     close(): Promise<MatDrawerToggleResult> {
         if (this._fixed) {
-            return Promise.resolve('open');
+            return Promise.resolve('close');
         }
         return this._sideNav.close();
     }
 
     toggle(): Promise<MatDrawerToggleResult> {
-        if (this._fixed) {
+        if (this._fixed && this._sideNav.opened) {
             return Promise.resolve('open');
         }
         return this._sideNav.toggle();
@@ -122,7 +122,7 @@ export abstract class AbstractNavigationDrawerComponent implements OnInit, After
             disableClose: true
         } : {
             mode: 'over',
-            opened: false,
+            opened: true,
             disableClose: false
         };
         if (bool && this._sideNav) {

--- a/projects/netgrif-components/src/lib/navigation/navigation-drawer/navigation-drawer.component.html
+++ b/projects/netgrif-components/src/lib/navigation/navigation-drawer/navigation-drawer.component.html
@@ -6,18 +6,40 @@
                  [resizeCursorPrecision]="10"
                  [resizeEdges]="{ right: true }"
                  (resizing)="onResizeEvent($event)">
-        <div fxLayout="column" fxLayoutAlign="start center" fxFlex>
-            <nc-user-card *ngIf="showUser" [user]="user" mode="full" [contentWidth]="contentWidth"></nc-user-card>
-            <mat-divider *ngIf="showUser" class="drawer-divider"></mat-divider>
-
-            <nc-quick-panel *ngIf="showQuickPanel" [items]="quickPanelItems" [contentWidth]="contentWidth"></nc-quick-panel>
-            <mat-divider *ngIf="showQuickPanel" class="drawer-divider"></mat-divider>
-
-            <nc-navigation-tree *ngIf="navigation" [contentWidth]="contentWidth"></nc-navigation-tree>
+        <div class="sidenav-wrapper">
+            <button
+                class="sidenav-close-button"
+                type="button"
+                aria-label="Toggle sidenav"
+                mat-icon-button
+                *ngIf="!fixed"
+                (click)="close()">
+                <mat-icon aria-label="Side nav toggle icon">close</mat-icon>
+            </button>
+            <div fxLayout="column" fxLayoutAlign="start center" fxFlex>
+                <nc-user-card *ngIf="showUser" [user]="user" mode="full" [contentWidth]="contentWidth"></nc-user-card>
+                <mat-divider *ngIf="showUser" class="drawer-divider"></mat-divider>
+                <nc-quick-panel *ngIf="showQuickPanel" [items]="quickPanelItems"
+                                [contentWidth]="contentWidth"></nc-quick-panel>
+                <mat-divider *ngIf="showQuickPanel" class="drawer-divider"></mat-divider>
+                <nc-navigation-tree *ngIf="navigation" [contentWidth]="contentWidth"></nc-navigation-tree>
+            </div>
         </div>
     </mat-sidenav>
 
     <mat-sidenav-content>
-        <ng-content></ng-content>
+        <div class="content-wrapper" fxLayout="row" fxLayoutAlign="space-between none">
+            <button
+                type="button"
+                aria-label="Toggle sidenav"
+                mat-icon-button
+                (click)="open()"
+                *ngIf="!sidenav.opened">
+                <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
+            </button>
+            <div fxFlex="100">
+                <ng-content></ng-content>
+            </div>
+        </div>
     </mat-sidenav-content>
 </mat-sidenav-container>

--- a/projects/netgrif-components/src/lib/navigation/navigation-drawer/navigation-drawer.component.scss
+++ b/projects/netgrif-components/src/lib/navigation/navigation-drawer/navigation-drawer.component.scss
@@ -14,3 +14,13 @@
 mat-divider.drawer-divider {
     width: 90%;
 }
+
+.sidenav-wrapper {
+    overflow-x: hidden !important;
+}
+
+.sidenav-close-button {
+    position: absolute;
+    right: 0;
+    z-index: 100;
+}


### PR DESCRIPTION
# Description

- added open and close button to drawer
- added support for opening the drawer when its closed due to small width of browser window

Fixes [NAE-1455]

## Dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

- Manually tested

### Test Configuration

- Linux Mint 20.3
- Node  version 12.22.10
- Npm version 6.14.16
- Default application parameters


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides

[NAE-1455]: https://netgrif.atlassian.net/browse/NAE-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ