### PR TITLE
[NAE-1575] User select component trying open non-exisisting side menu component

### DIFF
--- a/projects/netgrif-components-core/src/lib/side-menu/services/side-menu.service.ts
+++ b/projects/netgrif-components-core/src/lib/side-menu/services/side-menu.service.ts
@@ -52,6 +52,9 @@ export class SideMenuService {
     public open<T>(componentOrTemplateRef: ComponentType<T> | TemplateRef<T>,
                    width: SideMenuSize = SideMenuSize.MEDIUM,
                    injectionData?: SideMenuInjectionData): SideMenuRef {
+        if (!this.componentIsPresent()) {
+            throw new Error('Side menu is not initialized');
+        }
         if (this._sideMenuComponent.isOpened()) {
             throw new Error('Side menu has been already opened with another content');
         }
@@ -105,4 +108,8 @@ export class SideMenuService {
     // public toggle(isOpen?: boolean): Observable<MatDrawerToggleResult> {
     //     return from(this._sideMenu.toggle(isOpen));
     // }
+
+    private componentIsPresent(): boolean {
+        return !!this._sideMenuComponent;
+    }
 }


### PR DESCRIPTION
# Description

Fixes issue from NAB, where clicking the user data field in paper grid editor ends in error, as the side menu component does not exist in NAB.

Fixes [NAE-1575]

## Dependencies

No new dependencies was used in this branch.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

Tested manually, builded engine for NAB and tried to click it, now the correct message is thrown and not "undefined".

### Test Configuration

Host OS is macOS Monterey 12.1, the app was running on Angular 10.2.3 with Node 12.22.9 and NPM 6.14.15.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1575]: https://netgrif.atlassian.net/browse/NAE-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ