### PR TITLE
[NAE-1389] Immediate map data fields display their keys

### DIFF
--- a/projects/netgrif-components-core/src/lib/panel/abstract/panel-with-immediate-data.ts
+++ b/projects/netgrif-components-core/src/lib/panel/abstract/panel-with-immediate-data.ts
@@ -28,6 +28,11 @@ export abstract class PanelWithImmediateData extends PanelWithHeaderBinding impl
                     return {value: immediate.value.defaultValue, icon: undefined, type: immediate.type};
                 case 'multichoice':
                     return {value: immediate.value.map(it => it.defaultValue).join(', '), icon: undefined, type: immediate.type};
+                case 'enumeration_map':
+                    return {value: immediate.options[immediate.value].defaultValue, icon: undefined, type: immediate.type};
+                case 'multichoice_map':
+                    return {value: immediate.value.map(it =>
+                            immediate.options[it].defaultValue).join(', '), icon: undefined, type: immediate.type};
                 case 'file':
                     return {value: immediate.value?.name, icon: 'insert_drive_file', type: immediate.type};
                 case 'fileList':

--- a/projects/netgrif-components-core/src/lib/resources/interface/immediate-data.ts
+++ b/projects/netgrif-components-core/src/lib/resources/interface/immediate-data.ts
@@ -44,4 +44,8 @@ export interface ImmediateData {
      */
     // TODO Exists only in case immediate data
     name?: any;
+    /**
+     * Only for enumeration_map and multichoice_map
+     */
+    options?: { defaultValue?: string };
 }


### PR DESCRIPTION
# Description

If we choose immediate multichoice or enum map field, there are their keys displayed on case panel instead of their values.

Fixes [NAE-1389]

## Dependencies

There are no newly created or imported dependencies.

### Third party dependencies

There are no newly created or imported third party dependencies.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually, importing [all_data.xml](https://github.com/netgrif/application-engine/blob/master/src/main/resources/petriNets/all_data.xml) and setting the headers to immediate enum and multichoice map fields.

### Test Configuration

Host OS is macOS Monterey 12.1, the app was running on Angular 10.2.3 with Node 12.22.9 and NPM 6.14.15.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1389]: https://netgrif.atlassian.net/browse/NAE-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ