### PR TITLE
[NAE-1592] UserService user$ observable null value not checked

### DIFF
--- a/projects/nae-example-app/src/app/doc/public-resolver/public-resolver.component.ts
+++ b/projects/nae-example-app/src/app/doc/public-resolver/public-resolver.component.ts
@@ -29,7 +29,7 @@ export class PublicResolverComponent implements OnInit, OnDestroy {
                 this._router.navigate([this.redirectService.parseRedirectPath(this._publicResolver.url)],
                     { queryParams: this.redirectService.queryParams });
                 this._publicResolver.url = undefined;
-            } else if (!user || user.id === '') {
+            } else {
                 if (!this._sessionService.verified && !this._sessionService.isVerifying &&
                     this._sessionService.isInitialized && !this._auth.isAuthenticated) {
                     this._router.navigate([this.redirectService.parseRedirectPath(this._publicResolver.url)],

--- a/projects/nae-example-app/src/app/doc/public-resolver/public-resolver.component.ts
+++ b/projects/nae-example-app/src/app/doc/public-resolver/public-resolver.component.ts
@@ -25,11 +25,11 @@ export class PublicResolverComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         this._userSub = this._userService.user$.subscribe(user => {
-            if (user.id !== '') {
+            if (!!user && user.id !== '') {
                 this._router.navigate([this.redirectService.parseRedirectPath(this._publicResolver.url)],
                     { queryParams: this.redirectService.queryParams });
                 this._publicResolver.url = undefined;
-            } else if (user.id === '') {
+            } else if (!user || user.id === '') {
                 if (!this._sessionService.verified && !this._sessionService.isVerifying &&
                     this._sessionService.isInitialized && !this._auth.isAuthenticated) {
                     this._router.navigate([this.redirectService.parseRedirectPath(this._publicResolver.url)],

--- a/projects/netgrif-components-core/src/lib/authentication/components/abstract-authentication-overlay.ts
+++ b/projects/netgrif-components-core/src/lib/authentication/components/abstract-authentication-overlay.ts
@@ -21,7 +21,7 @@ export abstract class AbstractAuthenticationOverlay implements OnInit, OnDestroy
             this._spinnerOverlay.spin$.next(true);
             this.subSession = this._session.verifying.subscribe(active => {
                 this.userService.user$.subscribe(user => {
-                    if (!!user.id && user.id.length > 0) {
+                    if (!!user && !!user.id && user.id.length > 0) {
                         this.redirect(!active);
                     }
                 });

--- a/projects/netgrif-components-core/src/lib/groups/services/next-group.service.ts
+++ b/projects/netgrif-components-core/src/lib/groups/services/next-group.service.ts
@@ -32,7 +32,7 @@ export class NextGroupService implements OnDestroy {
 
         this._userSub = this._userService.user$.pipe(
             switchMap(user => {
-                if (user.id === '') {
+                if (!user || user.id === '') {
                     return of([]);
                 }
 


### PR DESCRIPTION
# Description

Fixes [NAE-1592]
 - check user$ null value in public resolver
 - check user$ null value in abstract authentication overlay
 - check user$ null value in next group service

## Dependencies

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually tested on demo application

### Test Configuration

Manually tested on demo application

| Name                | Tested on |
|---------------------| --------- |
| OS                  |Linux Mint 19.3           |
| Runtime             |node v12.16.1           |
| Dependency Manager  |npm 6.14.8          |
| Framework version   |Angular v10           |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mladoniczky @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1592]: https://netgrif.atlassian.net/browse/NAE-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ