### PR TITLE
[NAE-1613] Text selection in field value prevents task expansion panel header from reacting to click events

### DIFF
--- a/projects/netgrif-components/src/lib/panel/panel.component.scss
+++ b/projects/netgrif-components/src/lib/panel/panel.component.scss
@@ -27,3 +27,7 @@
 .margin-bottom {
     margin-bottom: 2px;
 }
+
+.mat-expansion-panel {
+    user-select: text !important;
+}


### PR DESCRIPTION
# Description

When a task panel was opened and a text was highlighted in datafield, the user was unable to close the task panel as it did not react to click event. The problem was caused by parent element "mat-sidenav-container", that in google chrome has "user-select" to "none". Fixed with adding explicit user-select: "text" to panel.component.scss

Fixes [NAE-1613]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually by clicking in Google Chrome browser.

### Test Configuration

This was tested on macOS Monterey 12.2.1 using Node 12.22.10 and NPM 6.14.16, implemented using Angular 10.2.3.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @timbez 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1613]: https://netgrif.atlassian.net/browse/NAE-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ