### PR TITLE
[NAE-1614] Advanced search substring query

### DIFF
--- a/projects/netgrif-components-core/src/lib/search/models/category/case/case-dataset.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/category/case/case-dataset.ts
@@ -260,13 +260,13 @@ export class CaseDataset extends Category<Datafield> implements AutocompleteOpti
             case 'file':
             case 'fileList':
                 return resolver.getIndex(datafield.fieldId, SearchIndex.FILE_NAME,
-                    this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals));
+                    this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals) || this.isSelectedOperator(Substring));
             case 'user':
             case 'userList':
                 return resolver.getIndex(datafield.fieldId, SearchIndex.USER_ID);
             default:
                 return resolver.getIndex(datafield.fieldId, SearchIndex.FULLTEXT,
-                    this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals));
+                    this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals) || this.isSelectedOperator(Substring));
         }
     }
 
@@ -415,10 +415,6 @@ export class CaseDataset extends Category<Datafield> implements AutocompleteOpti
             return (value as SearchAutocompleteOption<Array<number>>).value;
         }
         return value;
-    }
-
-    protected isSelectedOperator(operatorClass: Type<any>): boolean {
-        return this.selectedOperator === this._operatorService.getOperator(operatorClass);
     }
 
     serializeClass(): Categories | string {

--- a/projects/netgrif-components-core/src/lib/search/models/category/case/case-simple-dataset.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/category/case/case-simple-dataset.ts
@@ -86,14 +86,14 @@ export class CaseSimpleDataset extends NoConfigurationCategory<string> {
                 break;
             case 'file':
             case 'fileList':
-                this._elasticKeyword = resolver.getIndex(this._fieldId, SearchIndex.FILE_NAME);
+                this._elasticKeyword = resolver.getIndex(this._fieldId, SearchIndex.FILE_NAME, this.isSelectedOperator(Substring));
                 break;
             case 'user':
             case 'userList':
                 this._elasticKeyword = resolver.getIndex(this._fieldId, SearchIndex.USER_ID);
                 break;
             default:
-                this._elasticKeyword = resolver.getIndex(this._fieldId, SearchIndex.FULLTEXT);
+                this._elasticKeyword = resolver.getIndex(this._fieldId, SearchIndex.FULLTEXT, this.isSelectedOperator(Substring));
         }
     }
 

--- a/projects/netgrif-components-core/src/lib/search/models/category/case/case-title.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/category/case/case-title.ts
@@ -14,7 +14,7 @@ export class CaseTitle extends NoConfigurationCategory<string> {
     private static readonly _i18n = 'search.category.case.title';
 
     constructor(operators: OperatorService, logger: LoggerService) {
-        super([CaseSearch.TITLE],
+        super(undefined,
             [
                 operators.getOperator(Substring),
                 operators.getOperator(Equals),
@@ -37,5 +37,9 @@ export class CaseTitle extends NoConfigurationCategory<string> {
 
     serializeClass(): Categories | string {
         return Categories.CASE_TITLE;
+    }
+
+    protected get elasticKeywords(): Array<string> {
+        return [`${CaseSearch.TITLE}${this.isSelectedOperator(Substring) ? '.keyword' : ''}`];
     }
 }

--- a/projects/netgrif-components-core/src/lib/search/models/category/case/case-visual-id.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/category/case/case-visual-id.ts
@@ -7,13 +7,14 @@ import {Equals} from '../../operator/equals';
 import {NotEquals} from '../../operator/not-equals';
 import {Categories} from '../categories';
 import {CaseSearch} from './case-search.enum';
+import {Query} from "../../query/query";
 
 export class CaseVisualId extends NoConfigurationCategory<string> {
 
     private static readonly _i18n = 'search.category.case.visualId';
 
     constructor(operators: OperatorService, logger: LoggerService) {
-        super([CaseSearch.VISUAL_ID],
+        super(undefined,
             [operators.getOperator(Substring), operators.getOperator(Equals), operators.getOperator(NotEquals)],
             `${CaseVisualId._i18n}.name`,
             SearchInputType.TEXT,
@@ -31,5 +32,9 @@ export class CaseVisualId extends NoConfigurationCategory<string> {
 
     serializeClass(): Categories | string {
         return Categories.CASE_VISUAL_ID;
+    }
+
+    protected get elasticKeywords(): Array<string> {
+        return [`${CaseSearch.VISUAL_ID}${this.isSelectedOperator(Substring) ? '.keyword' : ''}`];
     }
 }

--- a/projects/netgrif-components-core/src/lib/search/models/category/case/case-visual-id.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/category/case/case-visual-id.ts
@@ -7,7 +7,6 @@ import {Equals} from '../../operator/equals';
 import {NotEquals} from '../../operator/not-equals';
 import {Categories} from '../categories';
 import {CaseSearch} from './case-search.enum';
-import {Query} from "../../query/query";
 
 export class CaseVisualId extends NoConfigurationCategory<string> {
 

--- a/projects/netgrif-components-core/src/lib/search/models/category/category.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/category/category.ts
@@ -16,6 +16,7 @@ import {Operators} from '../operator/operators';
 import {ofVoid} from '../../../utility/of-void';
 import {FilterTextSegment} from '../persistance/filter-text-segment';
 import {DATE_FORMAT_STRING, DATE_TIME_FORMAT_STRING} from '../../../moment/time-formats';
+import {Type} from '@angular/core';
 
 /**
  * The top level of abstraction in search query generation. Represents a set of indexed fields that can be searched.
@@ -323,7 +324,7 @@ export abstract class Category<T> {
         if (!this.isOperatorSelected()) {
             throw new Error('Category cannot generate a Query if no Operator is selected');
         }
-        return this._operatorFormControl.value.createQuery(this._elasticKeywords, userInput as unknown as Array<string>);
+        return this._operatorFormControl.value.createQuery(this.elasticKeywords, userInput as unknown as Array<string>);
     }
 
     /**
@@ -666,5 +667,14 @@ export abstract class Category<T> {
                 break;
         }
         return {segment, bold: true};
+    }
+
+    /**
+     * Checks for selected operator
+     * @param operatorClass the operator to be checked
+     * @return boolean of the statement
+     */
+    protected isSelectedOperator(operatorClass: Type<any>): boolean {
+        return this.selectedOperator === this._operatorService.getOperator(operatorClass);
     }
 }

--- a/projects/netgrif-components-core/src/lib/search/models/operator/substring.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/operator/substring.ts
@@ -16,8 +16,8 @@ export class Substring extends Operator<string> {
         // TODO IMPROVEMENT 27.4.2020 - we could use regular expressions to search for substrings which would solve the unintuitive
         //  behavior that occurs when we search for strings that contain spaces. We need to escape the input string in a special way
         //  if we choose to do this
-        const escapedValue = Operator.escapeInput(args[0]).value;
-        return Operator.forEachKeyword(elasticKeywords, keyword => new Query(`(${keyword}:\\*${escapedValue}\\*)`));
+        const escapedValue = Operator.escapeInput(args[0]).value.replace(' ', '\\ ');
+        return Operator.forEachKeyword(elasticKeywords, keyword => new Query(`(${keyword}:*${escapedValue}*)`));
     }
 
     getOperatorNameTemplate(): Array<string> {

--- a/projects/netgrif-components-core/src/lib/search/search-service/search.service.ts
+++ b/projects/netgrif-components-core/src/lib/search/search-service/search.service.ts
@@ -257,7 +257,8 @@ export class SearchService implements OnDestroy {
      * @param searchedSubstring value that should be searched on all full text fields
      */
     public setFullTextFilter(searchedSubstring: string): void {
-        this._fullTextFilter = new SimpleFilter('', this._baseFilter.type, {fullText: searchedSubstring});
+        const whiteSpacedSubstring = searchedSubstring.replace(' ', '\\ ');
+        this._fullTextFilter = new SimpleFilter('', this._baseFilter.type, {fullText: whiteSpacedSubstring});
         this.updateActiveFilter();
     }
 


### PR DESCRIPTION
# Description

Frontend filter does not work properly when searching for substring. The problem was that Elasticsearch was searching for the substring as a whole word, and not part of substring.

Fixes [NAE-1614]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |    macOS Montere 12.22.1       |
| Runtime             |  Node 12.22.10         |
| Dependency Manager  |  NPM 6.14.16        |
| Framework version   |   Angular 10        |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mladoniczky @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
