### PR TITLE
[NAE-1604] - Remove case creation button if there are no nets where user can create an instance

### DIFF
--- a/projects/netgrif-components-core/src/lib/utility/tests/utility/create-mock-net.ts
+++ b/projects/netgrif-components-core/src/lib/utility/tests/utility/create-mock-net.ts
@@ -1,6 +1,7 @@
 import {Net} from '../../../process/net';
 import NetRole from '../../../process/netRole';
 import {ImmediateData} from '../../../resources/interface/immediate-data';
+import {Permissions} from '../../../process/permissions';
 
 /**
  * A mock transition representation used by the {@link createMockNet} function to populate the mock net with mock transition objects
@@ -21,7 +22,8 @@ export function createMockNet(stringId = 'stringId',
                               title = 'title',
                               roles: Array<NetRole> = [],
                               transitions: Array<MockTransition> = [],
-                              immediateData: Array<ImmediateData> = []): Net {
+                              immediateData: Array<ImmediateData> = [],
+                              permissions: Permissions = {}): Net {
     const net = new Net({
         stringId,
         title,
@@ -42,5 +44,6 @@ export function createMockNet(stringId = 'stringId',
         petriNetId: '',
         immediateData: []
     }));
+    net.permissions = permissions;
     return net;
 }

--- a/projects/netgrif-components-core/src/lib/view/case-view/abstract-case-view.spec.ts
+++ b/projects/netgrif-components-core/src/lib/view/case-view/abstract-case-view.spec.ts
@@ -92,7 +92,7 @@ describe('AbstractCaseView', () => {
         it('should display create case button', (done) => {
             expect(component).toBeTruthy();
             caseViewService.getNewCaseAllowedNets().subscribe(nets => {
-                expect(allowedNetsService.allowedNets.length).toBe(1);
+                expect(component.canCreate).toBeTrue();
                 expect(component.hasAuthority()).toBeTrue();
                 done();
             });
@@ -120,7 +120,6 @@ describe('AbstractCaseView', () => {
 
         it('should not display create case button', () => {
             expect(component).toBeTruthy();
-            expect(allowedNetsService.allowedNets.length).toBe(0);
             expect(component.hasAuthority()).toBeFalse();
         });
 

--- a/projects/netgrif-components-core/src/lib/view/case-view/abstract-case-view.spec.ts
+++ b/projects/netgrif-components-core/src/lib/view/case-view/abstract-case-view.spec.ts
@@ -22,11 +22,13 @@ import {createMockNet} from '../../utility/tests/utility/create-mock-net';
 import {ProcessService} from '../../process/process.service';
 import {UserService} from '../../user/services/user.service';
 import {MockUserService} from '../../utility/tests/mocks/mock-user.service';
+import {User} from '../../user/models/user';
 
 describe('AbstractCaseView', () => {
     let component: TestCaseViewComponent;
     let fixture: ComponentFixture<TestCaseViewComponent>;
     let allowedNetsService: AllowedNetsService;
+    let caseViewService: CaseViewService;
 
     const imports = [
         MaterialModule,
@@ -54,6 +56,7 @@ describe('AbstractCaseView', () => {
         component = fixture.componentInstance;
         fixture.detectChanges();
         allowedNetsService = TestBed.inject(AllowedNetsService);
+        caseViewService = TestBed.inject(CaseViewService);
     };
 
     afterEach(() => {
@@ -70,7 +73,11 @@ describe('AbstractCaseView', () => {
                     {
                         provide: ProcessService,
                         useClass: MockProcessService
-                    }
+                    },
+                    {
+                        provide: UserService,
+                        useClass: CustomMockUserService
+                    },
                 ],
                 declarations: [TestCaseViewComponent]
             }).compileComponents();
@@ -82,10 +89,13 @@ describe('AbstractCaseView', () => {
             expect(component).toBeTruthy();
         });
 
-        it('should display create case button', () => {
+        it('should display create case button', (done) => {
             expect(component).toBeTruthy();
-            expect(allowedNetsService.allowedNets.length).toBe(1);
-            expect(component.hasAuthority()).toBeTrue();
+            caseViewService.getNewCaseAllowedNets().subscribe(nets => {
+                expect(allowedNetsService.allowedNets.length).toBe(1);
+                expect(component.hasAuthority()).toBeTrue();
+                done();
+            });
         });
     });
 
@@ -94,7 +104,10 @@ describe('AbstractCaseView', () => {
         beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports,
-                providers,
+                providers: [
+                    ...providers,
+                    {provide: AuthenticationMethodService, useClass: MockAuthenticationMethodService},
+                ],
                 declarations: [TestCaseViewComponent]
             }).compileComponents();
         }));
@@ -132,6 +145,34 @@ class TestCaseViewComponent extends AbstractCaseView {
 class MockProcessService {
 
     public getNets() {
-        return of([createMockNet()]);
+        return of([createMockNet(
+            'stringId',
+            'identifier',
+            'title',
+            [{
+                stringId: 'id',
+                name: 'id'
+            }], [], [], {
+                id: {
+                    create: true
+                }
+            }
+        )]);
+    }
+}
+
+@Injectable()
+class CustomMockUserService extends MockUserService {
+    constructor() {
+        super();
+        this._user = new User('123', 'test@netgrif.com', 'Test', 'User', ['ROLE_USER'], [{
+            stringId: 'id',
+            name: 'id',
+            description: '',
+            importId: 'id',
+            netImportId: 'identifier',
+            netVersion: '1.0.0',
+            netStringId: 'stringId',
+        }]);
     }
 }

--- a/projects/netgrif-components-core/src/lib/view/case-view/abstract-case-view.ts
+++ b/projects/netgrif-components-core/src/lib/view/case-view/abstract-case-view.ts
@@ -15,6 +15,7 @@ export abstract class AbstractCaseView extends ViewWithHeaders {
     public cases$: Observable<Array<Case>>;
     public loading: boolean;
     public authorityToCreate: Array<string>;
+    protected canCreate: boolean;
 
     protected constructor(protected _caseViewService: CaseViewService,
                           protected _overflowService?: OverflowService,
@@ -26,6 +27,9 @@ export abstract class AbstractCaseView extends ViewWithHeaders {
         super(_caseViewService);
         this._caseViewService.loading$.subscribe(loading => {
             this.loading = loading;
+        });
+        this._caseViewService.getNewCaseAllowedNets().subscribe(allowedNets => {
+            this.canCreate = allowedNets.length > 0;
         });
         this.cases$ = this._caseViewService.cases$;
         this.authorityToCreate = _authority.map(a => a.authority);
@@ -42,7 +46,7 @@ export abstract class AbstractCaseView extends ViewWithHeaders {
     public abstract handleCaseClick(clickedCase: Case): void;
 
     public hasAuthority(): boolean {
-        return (this._caseViewService.hasAuthority(this.authorityToCreate) && this._caseViewService.getAllowedNetsCount() > 0);
+        return (this._caseViewService.hasAuthority(this.authorityToCreate) && this.canCreate);
     }
 
     public getWidth() {

--- a/projects/netgrif-components-core/src/lib/view/case-view/abstract-case-view.ts
+++ b/projects/netgrif-components-core/src/lib/view/case-view/abstract-case-view.ts
@@ -15,8 +15,8 @@ export abstract class AbstractCaseView extends ViewWithHeaders implements OnDest
     public readonly headerType: HeaderType = HeaderType.CASE;
     public cases$: Observable<Array<Case>>;
     public loading: boolean;
+    public canCreate: boolean;
     public authorityToCreate: Array<string>;
-    protected canCreate: boolean;
     protected canCreateSub: Subscription;
 
     protected constructor(protected _caseViewService: CaseViewService,

--- a/projects/netgrif-components-core/src/lib/view/case-view/service/case-view-service.ts
+++ b/projects/netgrif-components-core/src/lib/view/case-view/service/case-view-service.ts
@@ -229,7 +229,7 @@ export class CaseViewService extends SortableView implements OnDestroy {
         return myCase;
     }
 
-    protected getNewCaseAllowedNets(): Observable<Array<PetriNetReferenceWithPermissions>> {
+    public getNewCaseAllowedNets(): Observable<Array<PetriNetReferenceWithPermissions>> {
         if (this._newCaseConfiguration.useCachedProcesses) {
             return this._allowedNetsService.allowedNets$.pipe(
                 map(net => net.filter(n => this._permissionService.hasNetPermission(PermissionType.CREATE, n)))


### PR DESCRIPTION
# Description

- update check for createNewCase button

Implements [NAE-1604](https://netgrif.atlassian.net/browse/NAE-1604)

## Dependencies

none

### Third party dependencies

none

### Blocking Pull requests

none

## How Has Been This Tested?

Manual test via example app


### Test Configuration


| Name                | Tested on |
|---------------------| --------- |
| OS                  |      Windows 10     |
| Runtime             |     Node v12.19.0      |
| Dependency Manager  |     npm 6.14.8      |
| Framework version   |           |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
