### PR TITLE
[NAE-1462] Change BaseAllowedNetService to always use observables

### DIFF
--- a/projects/netgrif-components-core/src/lib/allowed-nets/services/base-allowed-nets.service.ts
+++ b/projects/netgrif-components-core/src/lib/allowed-nets/services/base-allowed-nets.service.ts
@@ -30,6 +30,7 @@ export class BaseAllowedNetsService implements OnDestroy {
     }
 
     /**
+     * @deprecated
      * @returns the currently set allowed nets. Returns an empty array if no value was set.
      */
     public get allowedNets(): Array<string> {

--- a/projects/netgrif-components-core/src/lib/allowed-nets/services/base-allowed-nets.service.ts
+++ b/projects/netgrif-components-core/src/lib/allowed-nets/services/base-allowed-nets.service.ts
@@ -30,7 +30,7 @@ export class BaseAllowedNetsService implements OnDestroy {
     }
 
     /**
-     * @deprecated
+     * @deprecated This method should not be used. Use {@link BaseAllowedNetsService#allowedNets$} instead
      * @returns the currently set allowed nets. Returns an empty array if no value was set.
      */
     public get allowedNets(): Array<string> {


### PR DESCRIPTION
# Description

Implement use of getters in BaseAllowedNetsService that returns observable instead of the final array of process identifiers.

Implements [NAE-1462]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

<Depends on #(PR id)>/<There are no dependencies on other PR>

## How Has Been This Tested?

This was tested manually.

### Test Configuration

Netgrif Frontend PR Config
| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.2.1        |
| Runtime             |  Node 12.22.10         |
| Dependency Manager  |  NPM 6.14.16         |
| Framework version   |  Angular 10.2.3         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @minop 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1462]: https://netgrif.atlassian.net/browse/NAE-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ