### PR TITLE
[NAE-1435] Number field value NaN causes 'Maximum call stack size exceeded'

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/models/abstract-data-field.spec.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/models/abstract-data-field.spec.ts
@@ -1,0 +1,27 @@
+import {DataField} from './abstract-data-field';
+import {Behavior} from './behavior';
+
+describe('AbstractDataField', () => {
+    let testAbstractDataField: TestAbstractDataField;
+
+    beforeEach(() => {
+        testAbstractDataField = new TestAbstractDataField('', '', 0, {});
+    });
+    it('should check value equality for number values', () => {
+        expect(testAbstractDataField.checkValues(NaN, NaN)).toBeTrue();
+        expect(testAbstractDataField.checkValues(10, 10)).toBeTrue();
+        expect(testAbstractDataField.checkValues(10, NaN)).toBeFalse();
+        expect(testAbstractDataField.checkValues(NaN, 10)).toBeFalse();
+    });
+});
+
+class TestAbstractDataField extends DataField<any> {
+    constructor(_stringId: string, _title: string, initialValue: number,
+                _behavior: Behavior) {
+        super(_stringId, _title, initialValue, _behavior);
+    }
+
+    public checkValues<T>(a: any, b: any): boolean {
+        return this.valueEquality(a, b);
+    }
+}

--- a/projects/netgrif-components-core/src/lib/data-fields/models/abstract-data-field.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/models/abstract-data-field.ts
@@ -474,7 +474,7 @@ export abstract class DataField<T> {
      * @param b - second compared value
      */
     protected valueEquality(a: T, b: T): boolean {
-        return a === b;
+        return a === b || (Number.isNaN(a) && Number.isNaN(b));
     }
 
     /**


### PR DESCRIPTION
# Description

Fixes [NAE-1435]
- Add check for NaN value in function valueEquality().

## Dependencies

No new dependencies

### Third party dependencies

- No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manual testing

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  | Windows 10 |
| Runtime             | Node 12.18.3 |
| Dependency Manager  | NPM 6.14.6 |
| Framework version   | Angular 10 |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1435]: https://netgrif.atlassian.net/browse/NAE-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ