### PR TITLE
[NAE-1677] Message from exception thrown in SET event on data field is not propagated in EventOutcome

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/file-field/abstract-file-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/file-field/abstract-file-field.component.ts
@@ -259,14 +259,14 @@ export abstract class AbstractFileFieldComponent extends AbstractDataFieldCompon
                 this.state.error = true;
                 this.state.uploading = false;
                 this.state.progress = 0;
-                if (error?.error?.message) {
-                    this._snackbar.openErrorSnackBar(error.error.message);
-                } else {
-                    this._snackbar.openErrorSnackBar(this._translate.instant('dataField.snackBar.fileUploadFailed'));
-                }
                 this._log.error(
                     `File [${this.dataField.stringId}] ${this.fileUploadEl.nativeElement.files.item(0)} uploading has failed!`, error
                 );
+                if (error?.error?.message) {
+                    this._snackbar.openErrorSnackBar(this._translate.instant(error.error.message));
+                } else {
+                    this._snackbar.openErrorSnackBar(this._translate.instant('dataField.snackBar.fileUploadFailed'));
+                }
                 this.dataField.touch = true;
                 this.dataField.update();
                 this.fileUploadEl.nativeElement.value = '';

--- a/projects/netgrif-components-core/src/lib/data-fields/file-field/abstract-file-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/file-field/abstract-file-field.component.ts
@@ -259,10 +259,14 @@ export abstract class AbstractFileFieldComponent extends AbstractDataFieldCompon
                 this.state.error = true;
                 this.state.uploading = false;
                 this.state.progress = 0;
+                if (error?.error?.message) {
+                    this._snackbar.openErrorSnackBar(error.error.message);
+                } else {
+                    this._snackbar.openErrorSnackBar(this._translate.instant('dataField.snackBar.fileUploadFailed'));
+                }
                 this._log.error(
                     `File [${this.dataField.stringId}] ${this.fileUploadEl.nativeElement.files.item(0)} uploading has failed!`, error
                 );
-                this._snackbar.openErrorSnackBar(this._translate.instant('dataField.snackBar.fileUploadFailed'));
                 this.dataField.touch = true;
                 this.dataField.update();
                 this.fileUploadEl.nativeElement.value = '';

--- a/projects/netgrif-components-core/src/lib/data-fields/file-list-field/abstract-file-list-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/file-list-field/abstract-file-list-field.component.ts
@@ -207,10 +207,14 @@ export abstract class AbstractFileListFieldComponent extends AbstractDataFieldCo
                 this.state.error = true;
                 this.state.uploading = false;
                 this.state.progress = 0;
+                if (error?.error?.message) {
+                    this._snackbar.openErrorSnackBar(error.error.message);
+                } else {
+                    this._snackbar.openErrorSnackBar(this._translate.instant('dataField.snackBar.fileUploadFailed'));
+                }
                 this._log.error(
                     `File [${this.dataField.stringId}] ${this.fileUploadEl.nativeElement.files.item(0)} uploading has failed!`, error
                 );
-                this._snackbar.openErrorSnackBar(this._translate.instant('dataField.snackBar.fileUploadFailed'));
                 this.dataField.touch = true;
                 this.dataField.update();
                 this.fileUploadEl.nativeElement.value = '';

--- a/projects/netgrif-components-core/src/lib/data-fields/file-list-field/abstract-file-list-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/file-list-field/abstract-file-list-field.component.ts
@@ -208,7 +208,7 @@ export abstract class AbstractFileListFieldComponent extends AbstractDataFieldCo
                 this.state.uploading = false;
                 this.state.progress = 0;
                 if (error?.error?.message) {
-                    this._snackbar.openErrorSnackBar(error.error.message);
+                    this._snackbar.openErrorSnackBar(this._translate.instant(error.error.message));
                 } else {
                     this._snackbar.openErrorSnackBar(this._translate.instant('dataField.snackBar.fileUploadFailed'));
                 }

--- a/projects/netgrif-components-core/src/lib/resources/engine-endpoint/task-resource.service.ts
+++ b/projects/netgrif-components-core/src/lib/resources/engine-endpoint/task-resource.service.ts
@@ -1,7 +1,7 @@
 import {ConfigurationService} from '../../configuration/configuration.service';
 import {Injectable} from '@angular/core';
 import {Params, ProviderProgress, ResourceProvider} from '../resource-provider.service';
-import {Observable, throwError} from 'rxjs';
+import {Observable} from 'rxjs';
 import {Count} from '../interface/count';
 import {EventOutcomeMessageResource, MessageResource} from '../interface/message-resource';
 import {filter, map} from 'rxjs/operators';

--- a/projects/netgrif-components-core/src/lib/resources/engine-endpoint/task-resource.service.ts
+++ b/projects/netgrif-components-core/src/lib/resources/engine-endpoint/task-resource.service.ts
@@ -1,7 +1,7 @@
 import {ConfigurationService} from '../../configuration/configuration.service';
 import {Injectable} from '@angular/core';
 import {Params, ProviderProgress, ResourceProvider} from '../resource-provider.service';
-import {Observable} from 'rxjs';
+import {Observable, throwError} from 'rxjs';
 import {Count} from '../interface/count';
 import {EventOutcomeMessageResource, MessageResource} from '../interface/message-resource';
 import {filter, map} from 'rxjs/operators';
@@ -204,41 +204,45 @@ export class TaskResourceService extends AbstractResourceService implements Coun
     public getData(taskId: string): Observable<Array<DataGroup>> {
         return this.rawGetData(taskId).pipe(
             map((responseOutcome: EventOutcomeMessageResource) => {
-                const dataGroupsArray = this.changeType((responseOutcome.outcome as GetDataGroupsEventOutcome).data, 'dataGroups');
-                if (!Array.isArray(dataGroupsArray)) {
-                    return [];
-                }
-                const result = [];
-                dataGroupsArray.forEach(dataGroupResource => {
-                    const dataFields: Array<DataField<any>> = [];
-                    if (!dataGroupResource.fields._embedded) {
-                        return; // continue
+                if (responseOutcome.success) {
+                    const dataGroupsArray = this.changeType((responseOutcome.outcome as GetDataGroupsEventOutcome).data, 'dataGroups');
+                    if (!Array.isArray(dataGroupsArray)) {
+                        return [];
                     }
-                    const fields = [];
-                    Object.keys(dataGroupResource.fields._embedded).forEach(localizedFields => {
-                        fields.push(...dataGroupResource.fields._embedded[localizedFields]);
+                    const result = [];
+                    dataGroupsArray.forEach(dataGroupResource => {
+                        const dataFields: Array<DataField<any>> = [];
+                        if (!dataGroupResource.fields._embedded) {
+                            return; // continue
+                        }
+                        const fields = [];
+                        Object.keys(dataGroupResource.fields._embedded).forEach(localizedFields => {
+                            fields.push(...dataGroupResource.fields._embedded[localizedFields]);
+                        });
+                        fields.sort((a, b) => a.order - b.order);
+                        dataFields.push(...fields.map(dataFieldResource => this._fieldConverter.toClass(dataFieldResource)));
+                        const dataGroupObject: DataGroup = {
+                            fields: dataFields,
+                            stretch: dataGroupResource.stretch,
+                            title: dataGroupResource.title,
+                            layout: dataGroupResource.layout,
+                            alignment: dataGroupResource.alignment,
+                        };
+                        if (dataGroupResource.parentTaskId !== undefined) {
+                            dataGroupObject.parentTaskId = dataGroupResource.parentTaskId;
+                            dataGroupObject.parentTransitionId = dataGroupResource.parentTransitionId;
+                            dataGroupObject.parentTaskRefId = dataGroupResource.parentTaskRefId;
+                            dataGroupObject.nestingLevel = dataGroupResource.nestingLevel;
+                        }
+                        if (dataGroupResource.parentCaseId !== undefined) {
+                            dataGroupObject['parentCaseId'] = dataGroupResource.parentCaseId;
+                        }
+                        result.push(dataGroupObject);
                     });
-                    fields.sort((a, b) => a.order - b.order);
-                    dataFields.push(...fields.map(dataFieldResource => this._fieldConverter.toClass(dataFieldResource)));
-                    const dataGroupObject: DataGroup = {
-                        fields: dataFields,
-                        stretch: dataGroupResource.stretch,
-                        title: dataGroupResource.title,
-                        layout: dataGroupResource.layout,
-                        alignment: dataGroupResource.alignment,
-                    };
-                    if (dataGroupResource.parentTaskId !== undefined) {
-                        dataGroupObject.parentTaskId = dataGroupResource.parentTaskId;
-                        dataGroupObject.parentTransitionId = dataGroupResource.parentTransitionId;
-                        dataGroupObject.parentTaskRefId = dataGroupResource.parentTaskRefId;
-                        dataGroupObject.nestingLevel = dataGroupResource.nestingLevel;
-                    }
-                    if (dataGroupResource.parentCaseId !== undefined) {
-                        dataGroupObject['parentCaseId'] = dataGroupResource.parentCaseId;
-                    }
-                    result.push(dataGroupObject);
-                });
-                return result;
+                    return result;
+                } else {
+                    throw new Error(responseOutcome.error)
+                }
             })
         );
     }

--- a/projects/netgrif-components-core/src/lib/resources/engine-endpoint/task-resource.service.ts
+++ b/projects/netgrif-components-core/src/lib/resources/engine-endpoint/task-resource.service.ts
@@ -204,45 +204,45 @@ export class TaskResourceService extends AbstractResourceService implements Coun
     public getData(taskId: string): Observable<Array<DataGroup>> {
         return this.rawGetData(taskId).pipe(
             map((responseOutcome: EventOutcomeMessageResource) => {
-                if (responseOutcome.success) {
-                    const dataGroupsArray = this.changeType((responseOutcome.outcome as GetDataGroupsEventOutcome).data, 'dataGroups');
-                    if (!Array.isArray(dataGroupsArray)) {
-                        return [];
-                    }
-                    const result = [];
-                    dataGroupsArray.forEach(dataGroupResource => {
-                        const dataFields: Array<DataField<any>> = [];
-                        if (!dataGroupResource.fields._embedded) {
-                            return; // continue
-                        }
-                        const fields = [];
-                        Object.keys(dataGroupResource.fields._embedded).forEach(localizedFields => {
-                            fields.push(...dataGroupResource.fields._embedded[localizedFields]);
-                        });
-                        fields.sort((a, b) => a.order - b.order);
-                        dataFields.push(...fields.map(dataFieldResource => this._fieldConverter.toClass(dataFieldResource)));
-                        const dataGroupObject: DataGroup = {
-                            fields: dataFields,
-                            stretch: dataGroupResource.stretch,
-                            title: dataGroupResource.title,
-                            layout: dataGroupResource.layout,
-                            alignment: dataGroupResource.alignment,
-                        };
-                        if (dataGroupResource.parentTaskId !== undefined) {
-                            dataGroupObject.parentTaskId = dataGroupResource.parentTaskId;
-                            dataGroupObject.parentTransitionId = dataGroupResource.parentTransitionId;
-                            dataGroupObject.parentTaskRefId = dataGroupResource.parentTaskRefId;
-                            dataGroupObject.nestingLevel = dataGroupResource.nestingLevel;
-                        }
-                        if (dataGroupResource.parentCaseId !== undefined) {
-                            dataGroupObject['parentCaseId'] = dataGroupResource.parentCaseId;
-                        }
-                        result.push(dataGroupObject);
-                    });
-                    return result;
-                } else {
-                    throw new Error(responseOutcome.error)
+                if (responseOutcome.error) {
+                    throw new Error(responseOutcome.error);
                 }
+
+                const dataGroupsArray = this.changeType((responseOutcome.outcome as GetDataGroupsEventOutcome).data, 'dataGroups');
+                if (!Array.isArray(dataGroupsArray)) {
+                    return [];
+                }
+                const result = [];
+                dataGroupsArray.forEach(dataGroupResource => {
+                    const dataFields: Array<DataField<any>> = [];
+                    if (!dataGroupResource.fields._embedded) {
+                        return; // continue
+                    }
+                    const fields = [];
+                    Object.keys(dataGroupResource.fields._embedded).forEach(localizedFields => {
+                        fields.push(...dataGroupResource.fields._embedded[localizedFields]);
+                    });
+                    fields.sort((a, b) => a.order - b.order);
+                    dataFields.push(...fields.map(dataFieldResource => this._fieldConverter.toClass(dataFieldResource)));
+                    const dataGroupObject: DataGroup = {
+                        fields: dataFields,
+                        stretch: dataGroupResource.stretch,
+                        title: dataGroupResource.title,
+                        layout: dataGroupResource.layout,
+                        alignment: dataGroupResource.alignment,
+                    };
+                    if (dataGroupResource.parentTaskId !== undefined) {
+                        dataGroupObject.parentTaskId = dataGroupResource.parentTaskId;
+                        dataGroupObject.parentTransitionId = dataGroupResource.parentTransitionId;
+                        dataGroupObject.parentTaskRefId = dataGroupResource.parentTaskRefId;
+                        dataGroupObject.nestingLevel = dataGroupResource.nestingLevel;
+                    }
+                    if (dataGroupResource.parentCaseId !== undefined) {
+                        dataGroupObject['parentCaseId'] = dataGroupResource.parentCaseId;
+                    }
+                    result.push(dataGroupObject);
+                });
+                return result;
             })
         );
     }

--- a/projects/netgrif-components-core/src/lib/task/services/task-data.service.ts
+++ b/projects/netgrif-components-core/src/lib/task/services/task-data.service.ts
@@ -433,6 +433,14 @@ export class TaskDataService extends TaskHandlingService implements OnDestroy {
             });
     }
 
+    /**
+     * Processes a unsuccessful outcome of a `setData` request
+     * @param setTaskId the Id of the task whose data was set
+     * @param response the resulting Event outcome of the set data request
+     * @param afterAction the action that should be performed after the request is processed
+     * @param nextEvent indicates to the event queue that the next event can be processed
+     * @param body hold the data that was sent in request
+     */
     protected processUnsuccessfulSetDataRequest(setTaskId: string,
                                               response: EventOutcomeMessageResource,
                                               afterAction: AfterAction,

--- a/projects/netgrif-components-core/src/lib/task/services/task-data.service.ts
+++ b/projects/netgrif-components-core/src/lib/task/services/task-data.service.ts
@@ -239,7 +239,7 @@ export class TaskDataService extends TaskHandlingService implements OnDestroy {
      * @param nextEvent indicates to the event queue that the next event can be processed
      */
     protected processErroneousGetDataRequest(gottenTaskId: string,
-                                             error: HttpErrorResponse,
+                                             error: any,
                                              afterAction: AfterAction,
                                              nextEvent: AfterAction) {
         this._taskState.stopLoading(gottenTaskId);
@@ -252,9 +252,11 @@ export class TaskDataService extends TaskHandlingService implements OnDestroy {
             return;
         }
 
-        if (error.status === 500 && error.error.message && error.error.message.startsWith('Could not find task with id')) {
+        if (error instanceof HttpErrorResponse && error.status === 500 && error.error.message && error.error.message.startsWith('Could not find task with id')) {
             this._snackBar.openWarningSnackBar(this._translate.instant('tasks.snackbar.noLongerExists'));
             this._taskOperations.reload();
+        } else if (error instanceof Error) {
+            this._snackBar.openErrorSnackBar(this._translate.instant(error.message));
         } else {
             this._snackBar.openErrorSnackBar(`${this._translate.instant('tasks.snackbar.noGroup')}
                         ${this._taskContentService.task.title} ${this._translate.instant('tasks.snackbar.failedToLoad')}`);
@@ -413,7 +415,7 @@ export class TaskDataService extends TaskHandlingService implements OnDestroy {
 
         this._taskResourceService.setData(this._safeTask.stringId, body).pipe(take(1))
             .subscribe((response: EventOutcomeMessageResource) => {
-                this.processSuccessfulSetDataRequest(setTaskId, response.outcome, afterAction, nextEvent, body);
+                this.processSuccessfulSetDataRequest(setTaskId, response, afterAction, nextEvent, body);
             }, error => {
                 this.processErroneousSetDataRequest(setTaskId, error, afterAction, nextEvent, body);
             });
@@ -428,7 +430,7 @@ export class TaskDataService extends TaskHandlingService implements OnDestroy {
      * @param body hold the data that was sent in request
      */
     protected processSuccessfulSetDataRequest(setTaskId: string,
-                                              response: EventOutcome,
+                                              response: EventOutcomeMessageResource,
                                               afterAction: AfterAction,
                                               nextEvent: AfterAction,
                                               body: TaskSetDataRequestBody) {
@@ -441,15 +443,38 @@ export class TaskDataService extends TaskHandlingService implements OnDestroy {
             return;
         }
 
-        const changedFieldsMap: ChangedFieldsMap = this._eventService.parseChangedFieldsFromOutcomeTree(response);
+        if (response.success) {
+            const outcome = response.outcome;
+            const changedFieldsMap: ChangedFieldsMap = this._eventService.parseChangedFieldsFromOutcomeTree(outcome);
 
-        if (Object.keys(changedFieldsMap).length > 0) {
-            this._changedFieldsService.emitChangedFields(changedFieldsMap);
+            if (Object.keys(changedFieldsMap).length > 0) {
+                this._changedFieldsService.emitChangedFields(changedFieldsMap);
+            }
+            this.clearWaitingForResponseFlag(body);
+            this._snackBar.openSuccessSnackBar(!!outcome.message ? outcome.message : this._translate.instant('tasks.snackbar.dataSaved'));
+            this.updateStateInfo(afterAction, true, setTaskId);
+            nextEvent.resolve(true);
+
+        } else if (response.error !== undefined) {
+            if (response.error !== '') {
+                this._snackBar.openErrorSnackBar(this._translate.instant(response.error));
+            } else {
+                this._snackBar.openErrorSnackBar(this._translate.instant('tasks.snackbar.failedSave'));
+            }
+            if (response.outcome) {
+                const outcome = response.outcome;
+                const changedFieldsMap: ChangedFieldsMap = this._eventService.parseChangedFieldsFromOutcomeTree(outcome);
+
+                if (Object.keys(changedFieldsMap).length > 0) {
+                    this._changedFieldsService.emitChangedFields(changedFieldsMap);
+                }
+            }
+            this.revertToPreviousValue();
+            this.clearWaitingForResponseFlag(body);
+            this.updateStateInfo(afterAction, false, setTaskId);
+            nextEvent.resolve(false);
+            this._taskOperations.reload();
         }
-        this.clearWaitingForResponseFlag(body);
-        this._snackBar.openSuccessSnackBar(!!response.message ? response.message : this._translate.instant('tasks.snackbar.dataSaved'));
-        this.updateStateInfo(afterAction, true, setTaskId);
-        nextEvent.resolve(true);
     }
 
     /**


### PR DESCRIPTION
# Description

Refactoring of error handling so that error messages are displayed on the frontend

Fixes [NAE-1677]

## Dependencies

- No new dependencies were introduced

### Third party dependencies

- No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

I created net with events on set and get in witch an exception was thrown and after that message from exception showed in snack bar as error.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |  Windows 10         |
| Runtime             | Node 14.19.3        |
| Dependency Manager  |  NPM  6.14.17        |
| Framework version   | Angular 13          |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @machacjozef & @RudeBoyxX 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-1677]: https://netgrif.atlassian.net/browse/NAE-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ