### PR TITLE
[NAE-1626] Trigger of set event for fileList value deletion is not implemented

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/file-list-field/abstract-file-list-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/file-list-field/abstract-file-list-field.component.ts
@@ -78,7 +78,7 @@ export abstract class AbstractFileListFieldComponent extends AbstractDataFieldCo
 
     ngOnInit(): void {
         super.ngOnInit();
-        this.valueChange$ = this.dataField.valueChanges().subscribe(newValue => {
+        this.valueChange$ = this.dataField.valueChanges().subscribe(() => {
             this.parseResponse();
         });
         if (this.dataField.validations && this.dataField.validations.length !== 0) {
@@ -276,8 +276,11 @@ export abstract class AbstractFileListFieldComponent extends AbstractDataFieldCo
         }
 
         this._taskResourceService.deleteFile(this.taskId,
-            this.dataField.stringId, fileName).pipe(take(1)).subscribe(response => {
+            this.dataField.stringId, fileName).pipe(take(1)).subscribe((response: EventOutcomeMessageResource) => {
             if (response.success) {
+                const changedFieldsMap: ChangedFieldsMap = this._eventService.parseChangedFieldsFromOutcomeTree(response.outcome);
+                this.dataField.emitChangedFields(changedFieldsMap);
+                this.fileUploadEl.nativeElement.value = '';
                 this.uploadedFiles = this.uploadedFiles.filter(uploadedFile => uploadedFile !== fileName);
                 if (this.dataField.value.namesPaths) {
                     this.dataField.value.namesPaths = this.dataField.value.namesPaths.filter(namePath => namePath.name !== fileName);

--- a/projects/netgrif-components/src/lib/data-fields/enumeration-field/enumeration-stepper-field/enumeration-stepper-field.component.scss
+++ b/projects/netgrif-components/src/lib/data-fields/enumeration-field/enumeration-stepper-field/enumeration-stepper-field.component.scss
@@ -65,7 +65,6 @@
     border-top-style: solid;
     flex: auto;
     height: 0;
-    margin: 0 -16px;
     min-width: 12px;
 }
 


### PR DESCRIPTION
# Description

When deleting file from file list, set data events were not called.

Fixes [NAE-1626]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually and using unit tests.

### Test Configuration


| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.2.1        |
| Runtime             |  Node 14.19.3         |
| Dependency Manager  |  NPM 6.14.17        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mladoniczky
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1626]: https://netgrif.atlassian.net/browse/NAE-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ