### PR TITLE
[NAE-1713] Advanced search searching based on case data does not work

### DIFF
--- a/projects/netgrif-components-core/src/lib/search/models/category/case/case-dataset.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/category/case/case-dataset.ts
@@ -257,15 +257,18 @@ export class CaseDataset extends Category<Datafield> implements AutocompleteOpti
             case 'file':
             case 'fileList':
                 return resolver.getIndex(datafield.fieldId, SearchIndex.FILE_NAME,
-                    this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals) || this.isSelectedOperator(Substring));
+                    this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals) || this.isSelectedOperator(Substring)
+                    || this.isSelectedOperator(IsNull));
             case 'user':
             case 'userList':
                 return resolver.getIndex(datafield.fieldId, SearchIndex.USER_ID);
             case 'i18n':
-                return resolver.getIndex(datafield.fieldId, SearchIndex.TEXT, this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals) || this.isSelectedOperator(Substring))
+                return resolver.getIndex(datafield.fieldId, SearchIndex.TEXT, this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals) || this.isSelectedOperator(Substring)
+                    || this.isSelectedOperator(IsNull));
             default:
                 return resolver.getIndex(datafield.fieldId, SearchIndex.FULLTEXT,
-                    this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals) || this.isSelectedOperator(Substring));
+                    this.isSelectedOperator(Equals) || this.isSelectedOperator(NotEquals) || this.isSelectedOperator(Substring)
+                    || this.isSelectedOperator(IsNull));
         }
     }
 


### PR DESCRIPTION
# Description

Incorrect stack of cases were returned when used isNull filter on data in advanced search.  A 'keyword' was missing from the elastic query.

Fixes [NAE-1713]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually and using Postman

- <Name of a test [test file](link to the test file)>

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.2.1        |
| Runtime             |  Node 14.19.3         |
| Dependency Manager  |  NPM 6.14.17        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mladoniczky 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1713]: https://netgrif.atlassian.net/browse/NAE-1713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ