### PR TITLE
[NAE-1715] Currency component not working properly

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/number-field/currency-number-field/abstract-currency-number-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/number-field/currency-number-field/abstract-currency-number-field.component.ts
@@ -13,6 +13,7 @@ export abstract class AbstractCurrencyNumberFieldComponent extends AbstractNumbe
     fieldType: string;
     public readonly NUMBER_TYPE = 'number';
     public readonly TEXT_TYPE = 'text';
+    public readonly WHITESPACE = ' ';
 
     protected constructor(protected _currencyPipe: CurrencyPipe, translateService: TranslateService) {
         super(translateService);
@@ -24,7 +25,7 @@ export abstract class AbstractCurrencyNumberFieldComponent extends AbstractNumbe
         this.numberField.valueChanges().subscribe(value => {
             if (value !== undefined) {
                 if (this.fieldType === this.TEXT_TYPE) {
-                    this.transformedValue = this.transformCurrency(value.toString());
+                    this.transformedValue = this.transformCurrency(value.toString()) + this.WHITESPACE;
                 }
             } else {
                 this.transformedValue = '';


### PR DESCRIPTION
# Description

The currency field was not working when it was referenced through task ref, because after the value was changed, the field set value was called several times (maybe future refactor, unnecessary calls for set value on frontend), so the change detection on value input on input form field not worked after the second call for value, as the value of `transformedValue` was not changed, added whitespace to one transform result to always have different value on `transformedValue`.

Fixes [NAE-1715]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested with unit tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.2.1        |
| Runtime             |  Node 14.19.3         |
| Dependency Manager  |  NPM 6.14.17        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
