### PR TITLE
[NAE-1738] Multichoice map autocomplete init key

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/abstract-multichoice-autocomplete-field-component.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/abstract-multichoice-autocomplete-field-component.component.ts
@@ -84,7 +84,7 @@ export abstract class AbstractMultichoiceAutocompleteFieldComponentComponent imp
         return key;
     }
 
-    public getValueFromKey(key: string) {
-        return this.multichoiceField.choices.find(choice => choice.key === key).value;
+    public getValueFromKey(key: string): string | undefined {
+        return this.multichoiceField.choices.find(choice => choice.key === key)?.value;
     }
 }

--- a/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/abstract-multichoice-autocomplete-field-component.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/abstract-multichoice-autocomplete-field-component.component.ts
@@ -34,7 +34,7 @@ export abstract class AbstractMultichoiceAutocompleteFieldComponentComponent imp
     }
 
     add(event: MatChipInputEvent): void {
-        const value = (event.value || '').trim();
+        const value = (event['key'] || '').trim();
 
         if (value) {
             const choiceArray = [...this.multichoiceField.value];
@@ -82,5 +82,9 @@ export abstract class AbstractMultichoiceAutocompleteFieldComponentComponent imp
             }
         }
         return key;
+    }
+
+    public getValueFromKey(key: string) {
+        return this.multichoiceField.choices.find(choice => choice.key === key).value;
     }
 }

--- a/projects/netgrif-components/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/multichoice-autocomplete-field.component.html
+++ b/projects/netgrif-components/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/multichoice-autocomplete-field.component.html
@@ -3,7 +3,7 @@
     <mat-chip-list #chipList aria-label="Autocomplete" [formControl]="formControlRef">
         <mat-chip
             *ngFor="let option of multichoiceField.value" (removed)="remove(option)">
-            {{option}}
+            {{getValueFromKey(option)}}
             <button *ngIf="!formControlRef.disabled" matChipRemove>
                 <mat-icon>cancel</mat-icon>
             </button>
@@ -21,7 +21,7 @@
     </mat-chip-list>
     <mat-autocomplete [displayWith]="renderSelection" autoActiveFirstOption #auto="matAutocomplete">
         <mat-option [value]="null">---</mat-option>
-        <mat-option *ngFor="let option of filteredOptions | async" [value]="option.key" (onSelectionChange)="add(option)">
+        <mat-option *ngFor="let option of filteredOptions | async" [value]="option.key" (click)="add(option)">
             {{option.value}}
         </mat-option>
     </mat-autocomplete>


### PR DESCRIPTION
# Description

Implemented resolution of key-value instead of only-value in multichoice map autocomplete.

Fixes [NAE-1738]

## Dependencies

No new dependency were introduced.

### Third party dependencies

No new dependency were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Node 14.19.3         |
| Dependency Manager  |  NPM 6.14.17        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1738]: https://netgrif.atlassian.net/browse/NAE-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ