### PR TITLE
[NAE-1742] I18nField throws error on frontend when its value is null

### DIFF
--- a/projects/netgrif-components/src/lib/data-fields/i18n-field/i18n-divider-field/i18n-divider-field.component.html
+++ b/projects/netgrif-components/src/lib/data-fields/i18n-field/i18n-divider-field/i18n-divider-field.component.html
@@ -2,9 +2,9 @@
     <div fxFlex="20" class="divider-line"
          [ngClass]="{'divider-line-lgbt': isDividerLGBTQ(), 'primary-background-color': !dividerPropertyEnabled('dividerColor')}"
          [ngStyle]="dividerPropertyEnabled('dividerColor') && {'background': getDividerColor()}"></div>
-    <span [ngClass]="{'margin-default': dividerI18nField.value.defaultValue !== ''}"
+    <span *ngIf='!!dividerI18nField.value' [ngClass]="{'margin-default': dividerI18nField.value?.defaultValue !== ''}"
           [ngStyle]="dividerPropertyEnabled('fontSize') && {'font-size': getDividerFontSize()}">
-        {{dividerI18nField.value.defaultValue}}
+        {{dividerI18nField.value?.defaultValue ?? ''}}
     </span>
     <div fxFlex class="divider-line"
          [ngClass]="{'divider-line-lgbt': isDividerLGBTQ(), 'primary-background-color': !dividerPropertyEnabled('dividerColor')}"


### PR DESCRIPTION
# Description

On divider component, I18nField threw error when its value was set to null, because the template was not able to render the default value of null object. Added check avoid this issue.

Fixes [NAE-1742]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Node 14.19.3         |
| Dependency Manager  |  NPM 6.14.17        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
