### PR TITLE
[NAE-1751] Autocomplete new  filter "include"

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/abstract-enumeration-autocomplete-select-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/abstract-enumeration-autocomplete-select-field.component.ts
@@ -6,7 +6,7 @@ import {EnumerationField, EnumerationFieldValidation, EnumerationFieldValue} fro
 import {WrappedBoolean} from '../../data-field-template/models/wrapped-boolean';
 import {TranslateService} from '@ngx-translate/core';
 import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
-import {MultichoiceFieldValue} from '../../multichoice-field/models/multichoice-field';
+import {EnumerationAutocompleteFilterProperty} from './enumeration-autocomplete-filter-property';
 
 @Component({
     selector: 'ncc-abstract-enumeration-autocomplete-field',
@@ -71,11 +71,11 @@ export abstract class AbstractEnumerationAutocompleteSelectFieldComponent implem
     }
 
     protected _filter(value: string): Array<EnumerationFieldValue> {
-        let filterType = this.filterType().toLowerCase()
+        let filterType = this.filterType()?.toLowerCase()
         switch (filterType) {
-            case "include":
+            case EnumerationAutocompleteFilterProperty.SUBSTRING:
                 return this._filterInclude(value);
-            case "indexof":
+            case EnumerationAutocompleteFilterProperty.PREFIX:
                 return this._filterIndexOf(value);
             default:
                 return this._filterIndexOf(value);

--- a/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/abstract-enumeration-autocomplete-select-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/abstract-enumeration-autocomplete-select-field.component.ts
@@ -6,6 +6,7 @@ import {EnumerationField, EnumerationFieldValidation, EnumerationFieldValue} fro
 import {WrappedBoolean} from '../../data-field-template/models/wrapped-boolean';
 import {TranslateService} from '@ngx-translate/core';
 import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
+import {MultichoiceFieldValue} from '../../multichoice-field/models/multichoice-field';
 
 @Component({
     selector: 'ncc-abstract-enumeration-autocomplete-field',
@@ -44,18 +45,6 @@ export abstract class AbstractEnumerationAutocompleteSelectFieldComponent implem
         this.filteredOptions = undefined;
     }
 
-    /**
-     * Function to filter out matchless options without accent and case-sensitive differences
-     * @param  value to compare matching options
-     * @return  return matched options
-     */
-    private _filter(value: string): Array<EnumerationFieldValue> {
-        const filterValue = value?.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
-
-        return this.enumerationField.choices.filter(option => option.value.toLowerCase().normalize('NFD')
-            .replace(/[\u0300-\u036f]/g, '').indexOf(filterValue) === 0);
-    }
-
     change() {
         if (this.text.value !== undefined) {
             this.filteredOptions = of(this._filter(this.text.value));
@@ -69,6 +58,50 @@ export abstract class AbstractEnumerationAutocompleteSelectFieldComponent implem
 
     isInvalid(): boolean {
         return !this.formControlRef.disabled && !this.formControlRef.valid && this.text.control.touched;
+    }
+
+    protected checkPropertyInComponent(property: string): boolean {
+        return !!this.enumerationField.component && !!this.enumerationField.component.properties && property in this.enumerationField.component.properties;
+    }
+
+    protected filterType(): string | undefined {
+        if (this.checkPropertyInComponent('filter')) {
+            return this.enumerationField.component.properties.filter;
+        }
+    }
+
+    protected _filter(value: string): Array<EnumerationFieldValue> {
+        let filterType = this.filterType().toLowerCase()
+        switch (filterType) {
+            case "include":
+                return this._filterInclude(value);
+            case "indexof":
+                return this._filterIndexOf(value);
+            default:
+                return this._filterIndexOf(value);
+        }
+    }
+
+    protected _filterInclude(value: string): Array<EnumerationFieldValue> {
+        const filterValue = value?.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        return this.enumerationField.choices.filter(option =>
+            option.value.toLowerCase()
+                .normalize('NFD')
+                .replace(/[\u0300-\u036f]/g, '')
+                .includes(filterValue));
+    }
+
+
+    /**
+     * Function to filter out matchless options without accent and case-sensitive differences
+     * @param  value to compare matching options
+     * @return  return matched options
+     */
+    private _filterIndexOf(value: string): Array<EnumerationFieldValue> {
+        const filterValue = value?.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
+        return this.enumerationField.choices.filter(option => option.value.toLowerCase().normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '').indexOf(filterValue) === 0);
     }
 
     public renderSelection = (key) => {

--- a/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/abstract-enumeration-autocomplete-select-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/abstract-enumeration-autocomplete-select-field.component.ts
@@ -66,6 +66,11 @@ export abstract class AbstractEnumerationAutocompleteSelectFieldComponent implem
         this.formControlRef.setValue(event.option.value);
     }
 
+
+    isInvalid(): boolean {
+        return !this.formControlRef.disabled && !this.formControlRef.valid && this.text.control.touched;
+    }
+
     public renderSelection = (key) => {
         if (key !== undefined && key !== '' && key !== null) {
             if (this.enumerationField.choices.find(choice => choice.key === key)) {

--- a/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/abstract-enumeration-autocomplete-select-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/abstract-enumeration-autocomplete-select-field.component.ts
@@ -97,7 +97,7 @@ export abstract class AbstractEnumerationAutocompleteSelectFieldComponent implem
      * @param  value to compare matching options
      * @return  return matched options
      */
-    private _filterIndexOf(value: string): Array<EnumerationFieldValue> {
+    protected _filterIndexOf(value: string): Array<EnumerationFieldValue> {
         const filterValue = value?.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
         return this.enumerationField.choices.filter(option => option.value.toLowerCase().normalize('NFD')

--- a/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/enumeration-autocomplete-filter-property.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/enumeration-autocomplete-filter-property.ts
@@ -1,0 +1,4 @@
+export enum EnumerationAutocompleteFilterProperty {
+    PREFIX='prefix',
+    SUBSTRING='substring'
+}

--- a/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/abstract-multichoice-autocomplete-field-component.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/abstract-multichoice-autocomplete-field-component.component.ts
@@ -6,6 +6,7 @@ import {COMMA, ENTER} from '@angular/cdk/keycodes';
 import {MatChipInputEvent} from '@angular/material/chips';
 import {Observable, of} from 'rxjs';
 import {map, startWith} from 'rxjs/operators';
+import {MultichoiceAutocompleteFilterProperty} from './multichoice-autocomplete-filter-property';
 
 @Component({
     selector: 'ncc-abstract-multichoice-autocomplete-field',
@@ -76,11 +77,11 @@ export abstract class AbstractMultichoiceAutocompleteFieldComponentComponent imp
     }
 
     protected _filter(value: string): Array<MultichoiceFieldValue> {
-        let filterType = this.filterType().toLowerCase()
+        let filterType = this.filterType()?.toLowerCase()
         switch (filterType) {
-            case "include":
+            case MultichoiceAutocompleteFilterProperty.SUBSTRING:
                 return this._filterInclude(value);
-            case "indexof":
+            case MultichoiceAutocompleteFilterProperty.PREFIX:
                 return this._filterIndexOf(value);
             default:
                 return this._filterIndexOf(value);

--- a/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/abstract-multichoice-autocomplete-field-component.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/abstract-multichoice-autocomplete-field-component.component.ts
@@ -65,7 +65,37 @@ export abstract class AbstractMultichoiceAutocompleteFieldComponentComponent imp
         }
     }
 
-    private _filter(value: string): Array<MultichoiceFieldValue> {
+    protected checkPropertyInComponent(property: string): boolean {
+        return !!this.multichoiceField.component && !!this.multichoiceField.component.properties && property in this.multichoiceField.component.properties;
+    }
+
+    protected filterType(): string | undefined {
+        if (this.checkPropertyInComponent('filter')) {
+            return this.multichoiceField.component.properties.filter;
+        }
+    }
+
+    protected _filter(value: string): Array<MultichoiceFieldValue> {
+        let filterType = this.filterType().toLowerCase()
+        switch (filterType) {
+            case "include":
+                return this._filterInclude(value);
+            case "indexof":
+                return this._filterIndexOf(value);
+            default:
+                return this._filterIndexOf(value);
+        }
+    }
+
+    protected _filterInclude(value: string): Array<MultichoiceFieldValue> {
+        if (Array.isArray(value)) {
+            value = '';
+        }
+        const filterValue = value?.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        return this.multichoiceField.choices.filter(option => option.value.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').includes(filterValue));
+    }
+
+    protected _filterIndexOf(value: string): Array<MultichoiceFieldValue> {
         if (Array.isArray(value)) {
             value = '';
         }

--- a/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/multichoice-autocomplete-filter-property.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/multichoice-field/multichoice-autocomplete-field/multichoice-autocomplete-filter-property.ts
@@ -1,0 +1,4 @@
+export enum MultichoiceAutocompleteFilterProperty {
+    PREFIX='prefix',
+    SUBSTRING='substring'
+}

--- a/projects/netgrif-components-core/src/lib/data-fields/public-api.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/public-api.ts
@@ -80,6 +80,8 @@ export * from './filter-field/models/filter-field-injection-token';
 /* Enums */
 export * from './models/template-appearance';
 export * from './models/material-appearance';
+export * from './enumeration-field/enumeration-autocomplete-select-field/enumeration-autocomplete-filter-property'
+export * from './multichoice-field/multichoice-autocomplete-field/multichoice-autocomplete-filter-property'
 
 /* Services */
 export * from './i18n-field/language-icons.service';

--- a/projects/netgrif-components/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/enumeration-autocomplete-select-field.component.html
+++ b/projects/netgrif-components/src/lib/data-fields/enumeration-field/enumeration-autocomplete-select-field/enumeration-autocomplete-select-field.component.html
@@ -18,5 +18,5 @@
         </mat-option>
     </mat-autocomplete>
     <mat-hint>{{enumerationField.description}}</mat-hint>
-    <mat-error *ngIf="buildErrorMessage() !== undefined">{{buildErrorMessage()}}</mat-error>
+    <mat-error *ngIf="isInvalid() !== undefined">{{buildErrorMessage()}}</mat-error>
 </mat-form-field>


### PR DESCRIPTION
# Description

New  property in component

```
<component>
  <name>autocomplete</name>
  <property key="filter">substring</property>  OR   <property key="filter">prefix</property>
</component>
```
If miss  key="filter"  its  prefix type


Implements [NAE-1751]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

This was tested manually.

### Test Configuration


| Name                | Tested on |
|---------------------| --------- |
| OS                  |      Linux Mint 20.3     |
| Runtime             |  Node v12.22.12         |
| Dependency Manager  |   NPM 6.14.16    |
| Framework version   |    Angular 13.3.1     |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @minop          
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides

[NAE-1751]: https://netgrif.atlassian.net/browse/NAE-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ