### PR TITLE
[NAE-1752] MatPrefix for currency field overrides prefix for dateField

### DIFF
--- a/projects/netgrif-components/nae-theme.scss
+++ b/projects/netgrif-components/nae-theme.scss
@@ -38,7 +38,7 @@
     margin-bottom: 16px !important;
 }
 
-.mat-form-field .mat-form-field-prefix {
+nc-number-currency-field .mat-form-field .mat-form-field-prefix {
     position: initial !important;
     padding-right: 4px !important;
 }


### PR DESCRIPTION
# Description

Added selector for mat prefix style in nae_theme.css, cause it caused all the prefix being aligned in wrong way. Prefix alignment still has some bugs by default in Angular according to (issue)[https://github.com/angular/components/issues/12803]

Fixes [NAE-1752]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Node 14.19.3         |
| Dependency Manager  |  NPM 6.14.17        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @Kovy95 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides
