### PR TITLE
[NAE-1754] Currency field not displaying symbol

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/number-field/currency-number-field/abstract-currency-number-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/number-field/currency-number-field/abstract-currency-number-field.component.ts
@@ -23,7 +23,7 @@ export abstract class AbstractCurrencyNumberFieldComponent extends AbstractNumbe
         this.fieldType = this.TEXT_TYPE;
         this.transformedValue = this.transformCurrency(this.numberField.value?.toString());
         this.numberField.valueChanges().subscribe(value => {
-            if (value !== undefined) {
+            if (value !== undefined && value !== null) {
                 if (this.fieldType === this.TEXT_TYPE) {
                     this.transformedValue = this.transformCurrency(value.toString()) + this.WHITESPACE;
                 }


### PR DESCRIPTION
# Description

Currency field has a bug, when its value is set to null via actions. The problem is, that on frontend when converting changed value to currency text, the value is only checked for undefined, but not for null. Added check for null value.

Fixes [NAE-1754]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration


| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Node 14.19.3         |
| Dependency Manager  |  NPM 6.14.17        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1754]: https://netgrif.atlassian.net/browse/NAE-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ