### PR TITLE
[NAE-1762] Public view URL encoding

### DIFF
--- a/projects/nae-example-app/src/app/doc/public-workflow-view/public-workflow-view.component.ts
+++ b/projects/nae-example-app/src/app/doc/public-workflow-view/public-workflow-view.component.ts
@@ -66,6 +66,6 @@ export class PublicWorkflowViewComponent extends AbstractWorkflowViewComponent {
     }
 
     handleClick(workflow: Net) {
-        this._router.navigate([this._route.snapshot.url.join('/') + '/' + workflow.identifier]);
+        this._router.navigate([this._route.snapshot.url.join('/') + '/' + btoa(workflow.identifier)]);
     }
 }

--- a/projects/netgrif-components-core/src/lib/public/factories/get-net-and-create-case.ts
+++ b/projects/netgrif-components-core/src/lib/public/factories/get-net-and-create-case.ts
@@ -14,7 +14,7 @@ export const getNetAndCreateCase = (router: Router,
                                     snackBarService: SnackBarService,
                                     translate: TranslateService,
                                     publicTaskLoadingService: PublicTaskLoadingService) => {
-    process.getNet(route.snapshot.paramMap.get('petriNetId')).pipe(mergeMap(net => {
+    process.getNet(atob(route.snapshot.paramMap.get('petriNetId'))).pipe(mergeMap(net => {
         if (net) {
             publicTaskLoadingService.setLoading$(true);
             const newCase = {

--- a/projects/netgrif-components-core/src/lib/resources/engine-endpoint/public/public-petri-net-resource.service.ts
+++ b/projects/netgrif-components-core/src/lib/resources/engine-endpoint/public/public-petri-net-resource.service.ts
@@ -42,7 +42,7 @@ export class PublicPetriNetResourceService extends PetriNetResourceService {
      * **Request URL:** {{baseUrl}}/api/public/petrinet/{identifier}/{version}
      */
     public getOne(identifier: string, version: string, params?: Params): Observable<PetriNetReference> {
-        return this.provider.get$('public/petrinet/' + identifier + '/' + version, this.SERVER_URL, params)
+        return this.provider.get$('public/petrinet/' + btoa(identifier) + '/' + version, this.SERVER_URL, params)
             .pipe(map(r => this.changeType(r, 'petriNetReferences')));
     }
 


### PR DESCRIPTION
# Description

Added URL encoding and decoding to public factories, views and services for PetriNet identifiers to support identifiers in URI other than root.

Implements [NAE-1762]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Node 14.19.3         |
| Dependency Manager  |  NPM 6.14.17        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @machacjozef 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-engine)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif/project/ea82b3b8-658d-41f5-89a7-76cd600da01f)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1762]: https://netgrif.atlassian.net/browse/NAE-1762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ