### PR TITLE
[NAE-1763] FileField value is not promoted to the frontend after "set data event"

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/file-field/abstract-file-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/file-field/abstract-file-field.component.ts
@@ -171,6 +171,8 @@ export abstract class AbstractFileFieldComponent extends AbstractDataFieldCompon
             if (!!this.filePreview
                 && !!this.dataField.value
                 && !!this.dataField.value.name) {
+                this.fileForDownload = undefined;
+                this.fileForPreview = undefined;
                 this.initializePreviewIfDisplayable();
             }
         })


### PR DESCRIPTION
# Description

`fileForDownload` is set to undefined on fileField change in AbstractFileFieldComponent.

Fixes [NAE-1763]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Monterey 12.6        |
| Runtime             |  Java 11        |
| Dependency Manager  |  Maven 3.8.4         |
| Framework version   |  Spring Boot 2.6.2        |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @SamuelPalaj 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1763]: https://netgrif.atlassian.net/browse/NAE-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ