### PR TITLE
[NAE-1867] Fulltext replaces only first ' '

### DIFF
--- a/projects/netgrif-components-core/src/lib/search/models/operator/substring.ts
+++ b/projects/netgrif-components-core/src/lib/search/models/operator/substring.ts
@@ -16,7 +16,7 @@ export class Substring extends Operator<string> {
         // TODO IMPROVEMENT 27.4.2020 - we could use regular expressions to search for substrings which would solve the unintuitive
         //  behavior that occurs when we search for strings that contain spaces. We need to escape the input string in a special way
         //  if we choose to do this
-        const escapedValue = Operator.escapeInput(args[0]).value.replace(' ', '\\ ');
+        const escapedValue = Operator.escapeInput(args[0]).value.replace(/ /g, '\\ ');
         return Operator.forEachKeyword(elasticKeywords, keyword => new Query(`(${keyword}:*${escapedValue}*)`));
     }
 

--- a/projects/netgrif-components-core/src/lib/search/search-service/search.service.ts
+++ b/projects/netgrif-components-core/src/lib/search/search-service/search.service.ts
@@ -257,7 +257,7 @@ export class SearchService implements OnDestroy {
      * @param searchedSubstring value that should be searched on all full text fields
      */
     public setFullTextFilter(searchedSubstring: string): void {
-        const whiteSpacedSubstring = searchedSubstring.replace(' ', '\\ ');
+        const whiteSpacedSubstring = searchedSubstring.replace(/ /g, '\\ ');
         this._fullTextFilter = new SimpleFilter('', this._baseFilter.type, {fullText: whiteSpacedSubstring});
         this.updateActiveFilter();
     }


### PR DESCRIPTION
- replace string ' ' with regex / /g in both substring.ts and search.service.ts
