### PR TITLE
[NAE-1885] Side panel creates a new case when pressing Enter on date field

### DIFF
--- a/projects/netgrif-components-core/src/lib/side-menu/content-components/new-case/abstract-new-case.component.ts
+++ b/projects/netgrif-components-core/src/lib/side-menu/content-components/new-case/abstract-new-case.component.ts
@@ -15,7 +15,7 @@ import semver from 'semver';
 import {CreateCaseEventOutcome} from '../../../event/model/event-outcomes/case-outcomes/create-case-event-outcome';
 import {EventOutcomeMessageResource} from '../../../resources/interface/message-resource';
 import {MatOption} from '@angular/material/core';
-import { LoadingEmitter } from '../../../utility/loading-emitter';
+import {LoadingEmitter} from '../../../utility/loading-emitter';
 
 interface Form {
     value: string;
@@ -142,9 +142,14 @@ export abstract class AbstractNewCaseComponent implements OnDestroy {
     }
 
     public createNewCase(): void {
-        if(this.loadingSubmit.value){
-           return
+        if (this.loadingSubmit.value) {
+            return
         }
+
+        if (!this._sideMenuControl.isOpened()) {
+            return
+        }
+
         if (this.titleFormControl.valid || !this.isCaseTitleRequired()) {
             const newCase = {
                 title: this.titleFormControl.value === '' ? null : this.titleFormControl.value,
@@ -177,6 +182,8 @@ export abstract class AbstractNewCaseComponent implements OnDestroy {
                                     : response.error
                             });
                         }
+                        this.titleFormControl.markAsUntouched();
+                        this.titleFormControl.setValue(null);
                     },
                     error => {
                         this.loadingSubmit.off();


### PR DESCRIPTION
# Description

Fixes [NAE-1885]

- sidemenu: create new stream
- newcase: validation isOpened
- newcase: remove title


## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR.

## How Has Been This Tested?

This was tested manually, and with unit tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   macOS Ventura 13.3.1        |
| Runtime             |  Node 18.13.0        |
| Dependency Manager  |  NPM 8.19.3        |
| Framework version   |  Angular 13.3.1         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @renczesnetgrif 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [x] I have checked my contribution with code analysis tools:
    - [x] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [x] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides
    - [x] Migration Guides


[NAE-1885]: https://netgrif.atlassian.net/browse/NAE-1885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ