### PR TITLE
[NAE-1923] DateTime doesn't have locale and rework validation to isoWeekday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Full Changelog: [https://github.com/netgrif/components/commits/v6.3.1](https://github.com/netgrif/components/commits/v6.3.1)
+Full Changelog: [https://github.com/netgrif/components/commits/v6.3.2](https://github.com/netgrif/components/commits/v6.3.2)
+
+## [6.3.2](https://github.com/netgrif/components/releases/tag/v6.3.2) (2023-07-25)
+
+### Fixed
+
+- [NAE-1911] Autosave on text area in cooperation with button
+
 
 ## [6.3.1](https://github.com/netgrif/components/releases/tag/v6.3.1) (2023-07-18)
 

--- a/projects/netgrif-components-core/src/lib/data-fields/date-field/abstract-date-field.component.spec.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/date-field/abstract-date-field.component.spec.ts
@@ -20,7 +20,7 @@ import {TranslateService} from '@ngx-translate/core';
 import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token';
 import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
 import {LanguageService} from '../../translate/language.service';
-import {CustomDateAdapter} from 'netgrif-components-core';
+import {CustomDateAdapter} from './models/custom-date-adapter';
 
 describe('AbstractDateFieldComponent', () => {
     let component: TestDateFieldComponent;

--- a/projects/netgrif-components-core/src/lib/data-fields/date-field/abstract-date-field.component.spec.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/date-field/abstract-date-field.component.spec.ts
@@ -18,6 +18,9 @@ import {TranslateLibModule} from '../../translate/translate-lib.module';
 import {MaterialModule} from '../../material/material.module';
 import {TranslateService} from '@ngx-translate/core';
 import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+import {LanguageService} from '../../translate/language.service';
+import {CustomDateAdapter} from 'netgrif-components-core';
 
 describe('AbstractDateFieldComponent', () => {
     let component: TestDateFieldComponent;
@@ -36,6 +39,7 @@ describe('AbstractDateFieldComponent', () => {
                 {provide: AuthenticationService, useClass: MockAuthenticationService},
                 {provide: UserResourceService, useClass: MockUserResourceService},
                 {provide: ConfigurationService, useClass: TestConfigurationService},
+                {provide: DateAdapter, useClass: CustomDateAdapter}
             ],
             declarations: [
                 TestDateFieldComponent,
@@ -68,8 +72,11 @@ describe('AbstractDateFieldComponent', () => {
 })
 class TestDateFieldComponent extends AbstractDateFieldComponent {
     constructor(translate: TranslateService,
+                protected _adapter: DateAdapter<any>,
+                @Inject(MAT_DATE_LOCALE) protected _locale: string,
+                protected _languageService: LanguageService,
                 @Optional() @Inject(NAE_INFORM_ABOUT_INVALID_DATA) informAboutInvalidData: boolean | null) {
-        super(translate, informAboutInvalidData);
+        super(translate, _adapter, _locale, _languageService, informAboutInvalidData);
     }
 }
 

--- a/projects/netgrif-components-core/src/lib/data-fields/date-field/abstract-date-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/date-field/abstract-date-field.component.ts
@@ -3,6 +3,8 @@ import {DateField} from './models/date-field';
 import {AbstractTimeInstanceFieldComponent} from '../time-instance-abstract-field/abstract-time-instance-field.component';
 import {TranslateService} from '@ngx-translate/core';
 import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+import {LanguageService} from '../../translate/language.service';
 
 @Component({
     selector: 'ncc-abstract-date-field',
@@ -13,8 +15,11 @@ export abstract class AbstractDateFieldComponent extends AbstractTimeInstanceFie
     @Input() public dataField: DateField;
 
     protected constructor(protected _translate: TranslateService,
+                          protected _adapter: DateAdapter<any>,
+                          @Inject(MAT_DATE_LOCALE) protected _locale: string,
+                          protected _languageService: LanguageService,
                           @Optional() @Inject(NAE_INFORM_ABOUT_INVALID_DATA) informAboutInvalidData: boolean | null) {
-        super(_translate, informAboutInvalidData);
+        super(_translate, _adapter, _locale, _languageService, informAboutInvalidData);
     }
 
     getErrorMessage() {

--- a/projects/netgrif-components-core/src/lib/data-fields/date-time-field/abstract-date-time-field.component.spec.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/date-time-field/abstract-date-time-field.component.spec.ts
@@ -1,6 +1,6 @@
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {AngularResizeEventModule} from 'angular-resize-event';
-import {NgxMatDatetimePickerModule} from '@angular-material-components/datetime-picker';
+import {NgxMatDateAdapter, NgxMatDatetimePickerModule} from '@angular-material-components/datetime-picker';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Component, CUSTOM_ELEMENTS_SCHEMA, Inject, Optional} from '@angular/core';
@@ -21,6 +21,10 @@ import {MockUserResourceService} from '../../utility/tests/mocks/mock-user-resou
 import {TestConfigurationService} from '../../utility/tests/test-config';
 import {ConfigurationService} from '../../configuration/configuration.service';
 import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+import {LanguageService} from '../../translate/language.service';
+import {CustomDateAdapter} from 'netgrif-components-core';
+import {NgxMatMomentModule} from '@angular-material-components/moment-adapter';
 
 describe('AbstractDatetimeFieldComponent', () => {
     let component: TestDateTimeFieldComponent;
@@ -32,15 +36,17 @@ describe('AbstractDatetimeFieldComponent', () => {
                 MaterialModule,
                 AngularResizeEventModule,
                 NgxMatDatetimePickerModule,
+                NgxMatMomentModule,
                 TranslateLibModule,
                 HttpClientTestingModule,
-                NoopAnimationsModule
+                NoopAnimationsModule,
             ],
             providers: [
                 {provide: AuthenticationMethodService, useClass: MockAuthenticationMethodService},
                 {provide: AuthenticationService, useClass: MockAuthenticationService},
                 {provide: UserResourceService, useClass: MockUserResourceService},
-                {provide: ConfigurationService, useClass: TestConfigurationService}
+                {provide: ConfigurationService, useClass: TestConfigurationService},
+                {provide: DateAdapter, useClass: CustomDateAdapter}
             ],
             declarations: [
                 TestDateTimeFieldComponent,
@@ -72,8 +78,11 @@ describe('AbstractDatetimeFieldComponent', () => {
 })
 class TestDateTimeFieldComponent extends AbstractDateTimeFieldComponent {
     constructor(translate: TranslateService,
+                _adapter: NgxMatDateAdapter<any>,
+                @Inject(MAT_DATE_LOCALE) protected _locale: string,
+                _languageService: LanguageService,
                 @Optional() @Inject(NAE_INFORM_ABOUT_INVALID_DATA) informAboutInvalidData: boolean | null) {
-        super(translate, informAboutInvalidData);
+        super(translate, _adapter, _locale, _languageService, informAboutInvalidData);
     }
 }
 

--- a/projects/netgrif-components-core/src/lib/data-fields/date-time-field/abstract-date-time-field.component.spec.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/date-time-field/abstract-date-time-field.component.spec.ts
@@ -23,8 +23,8 @@ import {ConfigurationService} from '../../configuration/configuration.service';
 import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token';
 import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
 import {LanguageService} from '../../translate/language.service';
-import {CustomDateAdapter} from 'netgrif-components-core';
 import {NgxMatMomentModule} from '@angular-material-components/moment-adapter';
+import {CustomDateAdapter} from '../date-field/models/custom-date-adapter';
 
 describe('AbstractDatetimeFieldComponent', () => {
     let component: TestDateTimeFieldComponent;

--- a/projects/netgrif-components-core/src/lib/data-fields/date-time-field/abstract-date-time-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/date-time-field/abstract-date-time-field.component.ts
@@ -3,6 +3,9 @@ import {DateTimeField} from './models/date-time-field';
 import {AbstractTimeInstanceFieldComponent} from '../time-instance-abstract-field/abstract-time-instance-field.component';
 import {TranslateService} from '@ngx-translate/core';
 import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token';
+import {MAT_DATE_LOCALE} from '@angular/material/core';
+import {LanguageService} from '../../translate/language.service';
+import {NgxMatDateAdapter} from '@angular-material-components/datetime-picker';
 
 @Component({
     selector: 'ncc-abstract-date-time-field',
@@ -13,8 +16,11 @@ export abstract class AbstractDateTimeFieldComponent extends AbstractTimeInstanc
     @Input() public dataField: DateTimeField;
 
     protected constructor(protected _translate: TranslateService,
+                          protected _adapter: NgxMatDateAdapter<any>,
+                          @Inject(MAT_DATE_LOCALE) protected _locale: string,
+                          protected _languageService: LanguageService,
                           @Optional() @Inject(NAE_INFORM_ABOUT_INVALID_DATA) informAboutInvalidData: boolean | null) {
-        super(_translate, informAboutInvalidData);
+        super(_translate, _adapter, _locale, _languageService, informAboutInvalidData);
     }
 
     getErrorMessage() {

--- a/projects/netgrif-components-core/src/lib/data-fields/time-instance-abstract-field/abstract-time-instance-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/time-instance-abstract-field/abstract-time-instance-field.component.ts
@@ -2,17 +2,18 @@ import {AbstractDataFieldComponent} from '../models/abstract-data-field-componen
 import {AbstractTimeInstanceField, AbstractTimeInstanceFieldValidation} from './models/abstract-time-instance-field';
 import {TranslateService} from '@ngx-translate/core';
 import moment, {Moment} from 'moment';
-import {Component, Inject, Optional} from '@angular/core';
+import {Component, Inject, OnDestroy, Optional} from '@angular/core';
 import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token';
 import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
 import {LanguageService} from '../../translate/language.service';
+import {Subscription} from 'rxjs';
 
 @Component({
     selector: 'ncc-abstract-time-instance-field',
     template: ''
 })
-export abstract class AbstractTimeInstanceFieldComponent extends AbstractDataFieldComponent {
-
+export abstract class AbstractTimeInstanceFieldComponent extends AbstractDataFieldComponent implements OnDestroy {
+    protected _subLang: Subscription;
     protected constructor(protected _translate: TranslateService,
                           protected _adapter: DateAdapter<any>,
                           @Inject(MAT_DATE_LOCALE) protected _locale: string,
@@ -22,11 +23,16 @@ export abstract class AbstractTimeInstanceFieldComponent extends AbstractDataFie
         if (this._locale !== this._languageService.getLanguage()) {
             this.setLangToAdapter(this._languageService.getLanguage());
         }
-        this._languageService.getLangChange$().subscribe(lang => {
+        this._subLang = this._languageService.getLangChange$().subscribe(lang => {
             if (this._locale !== lang) {
                 this.setLangToAdapter(lang);
             }
         });
+    }
+
+    ngOnDestroy() {
+        super.ngOnDestroy();
+        this._subLang.unsubscribe();
     }
 
     protected setLangToAdapter(lang: string) {

--- a/projects/netgrif-components-core/src/lib/data-fields/time-instance-abstract-field/abstract-time-instance-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/time-instance-abstract-field/abstract-time-instance-field.component.ts
@@ -4,6 +4,8 @@ import {TranslateService} from '@ngx-translate/core';
 import moment, {Moment} from 'moment';
 import {Component, Inject, Optional} from '@angular/core';
 import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token';
+import {DateAdapter, MAT_DATE_LOCALE} from '@angular/material/core';
+import {LanguageService} from '../../translate/language.service';
 
 @Component({
     selector: 'ncc-abstract-time-instance-field',
@@ -12,8 +14,24 @@ import {NAE_INFORM_ABOUT_INVALID_DATA} from '../models/invalid-data-policy-token
 export abstract class AbstractTimeInstanceFieldComponent extends AbstractDataFieldComponent {
 
     protected constructor(protected _translate: TranslateService,
+                          protected _adapter: DateAdapter<any>,
+                          @Inject(MAT_DATE_LOCALE) protected _locale: string,
+                          protected _languageService: LanguageService,
                           @Optional() @Inject(NAE_INFORM_ABOUT_INVALID_DATA) informAboutInvalidData: boolean | null) {
         super(informAboutInvalidData);
+        if (this._locale !== this._languageService.getLanguage()) {
+            this.setLangToAdapter(this._languageService.getLanguage());
+        }
+        this._languageService.getLangChange$().subscribe(lang => {
+            if (this._locale !== lang) {
+                this.setLangToAdapter(lang);
+            }
+        });
+    }
+
+    protected setLangToAdapter(lang: string) {
+        this._locale = lang
+        this._adapter.setLocale(this._locale);
     }
 
     public buildErrorMessage(dataField: AbstractTimeInstanceField) {

--- a/projects/netgrif-components-core/src/lib/data-fields/time-instance-abstract-field/models/abstract-time-instance-field.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/time-instance-abstract-field/models/abstract-time-instance-field.ts
@@ -108,12 +108,12 @@ export abstract class AbstractTimeInstanceField extends DataField<Moment> {
     }
 
     protected validWorkday(fc: FormControl) {
-        const dayOfWeek = !!fc.value ? fc.value.weekday() : null;
-        return dayOfWeek === 6 || dayOfWeek === 0 ? {validWorkday: true} : null;
+        const dayOfWeek = !!fc.value ? fc.value.isoWeekday() : null;
+        return dayOfWeek === 6 || dayOfWeek === 7 ? {validWorkday: true} : null;
     }
 
     protected validWeekend(fc: FormControl) {
-        const dayOfWeek = !!fc.value ? fc.value.weekday() : null;
-        return dayOfWeek >= 1 && dayOfWeek <= 5 && dayOfWeek !== 0 ? {validWeekend: true} : null;
+        const dayOfWeek = !!fc.value ? fc.value.isoWeekday() : null;
+        return dayOfWeek >= 1 && dayOfWeek <= 5 ? {validWeekend: true} : null;
     }
 }

--- a/projects/netgrif-components/src/lib/data-fields/date-field/date-field.component.ts
+++ b/projects/netgrif-components/src/lib/data-fields/date-field/date-field.component.ts
@@ -1,6 +1,6 @@
 import {Component, Inject, Optional} from '@angular/core';
-import {MAT_DATE_FORMATS} from '@angular/material/core';
-import {AbstractDateFieldComponent, DATE_FORMAT, NAE_INFORM_ABOUT_INVALID_DATA} from '@netgrif/components-core';
+import {DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE} from '@angular/material/core';
+import {AbstractDateFieldComponent, DATE_FORMAT, NAE_INFORM_ABOUT_INVALID_DATA, LanguageService} from '@netgrif/components-core';
 import {TranslateService} from '@ngx-translate/core';
 
 
@@ -14,7 +14,10 @@ import {TranslateService} from '@ngx-translate/core';
 })
 export class DateFieldComponent extends AbstractDateFieldComponent {
     constructor(translate: TranslateService,
+                protected _adapter: DateAdapter<any>,
+                @Inject(MAT_DATE_LOCALE) protected _locale: string,
+                protected _languageService: LanguageService,
                 @Optional() @Inject(NAE_INFORM_ABOUT_INVALID_DATA) informAboutInvalidData: boolean | null) {
-        super(translate, informAboutInvalidData);
+        super(translate, _adapter, _locale, _languageService, informAboutInvalidData);
     }
 }

--- a/projects/netgrif-components/src/lib/data-fields/date-time-field/date-time-field.component.spec.ts
+++ b/projects/netgrif-components/src/lib/data-fields/date-time-field/date-time-field.component.spec.ts
@@ -23,6 +23,7 @@ import {
     UserResourceService
 } from '@netgrif/components-core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {NgxMatMomentModule} from '@angular-material-components/moment-adapter';
 
 describe('DatetimeFieldComponent', () => {
     let component: DateTimeFieldComponent;
@@ -34,6 +35,7 @@ describe('DatetimeFieldComponent', () => {
                 MaterialModule,
                 AngularResizeEventModule,
                 NgxMatDatetimePickerModule,
+                NgxMatMomentModule,
                 TranslateLibModule, HttpClientTestingModule, NoopAnimationsModule
             ],
             providers: [

--- a/projects/netgrif-components/src/lib/data-fields/date-time-field/date-time-field.component.ts
+++ b/projects/netgrif-components/src/lib/data-fields/date-time-field/date-time-field.component.ts
@@ -1,7 +1,8 @@
 import {Component, Inject, Optional} from '@angular/core';
-import {NGX_MAT_DATE_FORMATS} from '@angular-material-components/datetime-picker';
+import {NGX_MAT_DATE_FORMATS, NgxMatDateAdapter} from '@angular-material-components/datetime-picker';
 import {TranslateService} from '@ngx-translate/core';
-import {AbstractDateTimeFieldComponent, DATE_TIME_FORMAT, NAE_INFORM_ABOUT_INVALID_DATA} from '@netgrif/components-core';
+import {AbstractDateTimeFieldComponent, DATE_TIME_FORMAT, NAE_INFORM_ABOUT_INVALID_DATA, LanguageService} from '@netgrif/components-core';
+import {MAT_DATE_LOCALE} from '@angular/material/core';
 
 @Component({
     selector: 'nc-date-time-field',
@@ -14,7 +15,10 @@ import {AbstractDateTimeFieldComponent, DATE_TIME_FORMAT, NAE_INFORM_ABOUT_INVAL
 export class DateTimeFieldComponent extends AbstractDateTimeFieldComponent {
 
     constructor(translate: TranslateService,
+                protected _adapter: NgxMatDateAdapter<any>,
+                @Inject(MAT_DATE_LOCALE) protected _locale: string,
+                protected _languageService: LanguageService,
                 @Optional() @Inject(NAE_INFORM_ABOUT_INVALID_DATA) informAboutInvalidData: boolean | null) {
-        super(translate, informAboutInvalidData);
+        super(translate, _adapter, _locale, _languageService, informAboutInvalidData);
     }
 }


### PR DESCRIPTION
# Description
- add locale to date fields (needed in datetime field)
- rework of validations from weekday to isoWeekday

Fixes [NAE-1923]

## Dependencies

none

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

manually

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |  LINUX MINT  20.3       |
| Runtime             |    NodeJS 14.21.3       |
| Dependency Manager  |    NPM  6.14.18      |
| Framework version   |     Angular 13      |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-1923]: https://netgrif.atlassian.net/browse/NAE-1923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ