### PR TITLE
[NAE-1983] Public view file handling

### DIFF
--- a/projects/netgrif-components-core/src/lib/resources/engine-endpoint/public/public-task-resource.service.ts
+++ b/projects/netgrif-components-core/src/lib/resources/engine-endpoint/public/public-task-resource.service.ts
@@ -121,7 +121,7 @@ export class PublicTaskResourceService extends TaskResourceService {
      * GET
      */
     public downloadFile(taskId: string, params: HttpParams): Observable<ProviderProgress | Blob> {
-        const url = `task/${taskId}/file${params?.has("fileName") ? '/named' : ''}`;
+        const url = `public/task/${taskId}/file${params?.has("fileName") ? '/named' : ''}`;
         return this._resourceProvider.getBlob$(url, this.SERVER_URL, params).pipe(
             map(event => {
                 switch (event.type) {


### PR DESCRIPTION
 - fix the problem

# Description

<Please include a summary of the changes and which issue is fixed. Please also include relevant links and special instructions if applicable.>

Fixes [NAE-1983]

## Dependencies

none

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

tested manually

### Test Configuration

<Please describe configuration for tests to run if applicable, like program parameters, host OS, VM configuration etc. You can use >

| Name                | Tested on |
|---------------------| --------- |
| OS                  |     LinuxMint 20     |
| Runtime             |     NodeJS 20.11.0      |
| Dependency Manager  |     NPM 10.2.4      |
| Framework version   |    Angular 13       |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-1983]: https://netgrif.atlassian.net/browse/NAE-1983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ