### PR TITLE
[NAE-1949] Allowed Types for Filefield

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/file-field/file-default-field/abstract-file-default-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/file-field/file-default-field/abstract-file-default-field.component.ts
@@ -3,7 +3,6 @@ import {
     Component,
     ElementRef,
     Inject,
-    Input,
     OnDestroy,
     OnInit,
     Optional,
@@ -17,7 +16,6 @@ import {LoggerService} from "../../../logger/services/logger.service";
 import {SnackBarService} from "../../../snack-bar/services/snack-bar.service";
 import {TranslateService} from "@ngx-translate/core";
 import {EventService} from "../../../event/services/event.service";
-import {FileFieldIdBody} from "../../models/file-field-id-body";
 import {EventOutcomeMessageResource} from "../../../resources/interface/message-resource";
 import {ProgressType, ProviderProgress} from "../../../resources/resource-provider.service";
 import {ChangedFieldsMap} from "../../../event/services/interfaces/changed-fields-map";
@@ -205,9 +203,7 @@ export abstract class AbstractFileDefaultFieldComponent extends AbstractFileFiel
         if (this.dataField.maxUploadSizeInBytes &&
             this.dataField.maxUploadSizeInBytes < this.fileUploadEl.nativeElement.files.item(0).size) {
             this._log.error('File cannot be uploaded. Maximum size of file exceeded.');
-            this._snackbar.openErrorSnackBar(
-                this._translate.instant('dataField.snackBar.maxFilesSizeExceeded') + this.dataField.maxUploadSizeInBytes
-            );
+            this.resolveMaxSizeMessage();
             this.fileUploadEl.nativeElement.value = '';
             return;
         }

--- a/projects/netgrif-components-core/src/lib/data-fields/file-list-field/file-list-default-field/abstract-file-list-default-field.component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/file-list-field/file-list-default-field/abstract-file-list-default-field.component.ts
@@ -138,9 +138,7 @@ export abstract class AbstractFileListDefaultFieldComponent extends AbstractFile
         if (this.dataField.maxUploadSizeInBytes &&
             this.dataField.maxUploadSizeInBytes < sum) {
             this._log.error('Files cannot be uploaded. Maximum size of files exceeded.');
-            this._snackbar.openErrorSnackBar(
-                this._translate.instant('dataField.snackBar.maxFilesSizeExceeded') + this.dataField.maxUploadSizeInBytes
-            );
+            this.resolveMaxSizeMessage();
             this.fileUploadEl.nativeElement.value = '';
             return;
         }

--- a/projects/netgrif-components-core/src/lib/data-fields/models/abstract-file-field-default-component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/models/abstract-file-field-default-component.ts
@@ -80,4 +80,14 @@ export abstract class AbstractFileFieldDefaultComponent<T extends FileField | Fi
     protected resolveParentTaskId(): string {
         return !!this.dataField.parentTaskId ? this.dataField.parentTaskId : this.taskId;
     }
+
+    protected resolveMaxSizeMessage() {
+        if (this.dataField?.component?.properties?.maxSizeMessage) {
+            this._snackbar.openErrorSnackBar(this._translate.instant(this.dataField?.component?.properties?.maxSizeMessage));
+        } else {
+            this._snackbar.openErrorSnackBar(
+                this._translate.instant('dataField.snackBar.maxFilesSizeExceeded') + this.dataField.maxUploadSizeInBytes * 0.000001 + 'MB'
+            );
+        }
+    }
 }


### PR DESCRIPTION
# Description
 - fix the problem with showing byte size in snackbar, changed to MB, add message as property

Fixes [NAE-1949]

## Dependencies

none

### Third party dependencies

- No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?
manually

### Test Configuration


| Name                | Tested on |
|---------------------| --------- |
| OS                  |      LinuxMint 20     |
| Runtime             |     NodeJS 20.11.0      |
| Dependency Manager  |     NPM 10.2.4      |
| Framework version   |    Angular 13       |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-1949]: https://netgrif.atlassian.net/browse/NAE-1949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ