### PR TITLE
[NAE-2036] Task-List-View to open Case by link

### DIFF
--- a/nae.json
+++ b/nae.json
@@ -242,6 +242,15 @@
                     },
                     "processUri": "/"
                 },
+                "task-list-view": {
+                    "component": {
+                        "class": "DefaultSimpleTaskViewComponent"
+                    },
+                    "access": "private",
+                    "routing": {
+                        "path": "task-list/:singleCaseId"
+                    }
+                },
                 "hidden-workflow-view": {
                     "component": {
                         "class": "WorkflowViewExampleComponent",

--- a/projects/nae-example-app/src/app/nae-example-app-view.service.ts
+++ b/projects/nae-example-app/src/app/nae-example-app-view.service.ts
@@ -42,6 +42,7 @@ import {BreadcrumbsExampleComponent} from './doc/breadcrumbs-example/breadcrumbs
 import {DashboardCaseExampleComponent} from './doc/dashboard-case-example/dashboard-case-example.component';
 import {ImpersonationDemoComponent} from './doc/impersonation-demo/impersonation-demo.component';
 import {ChangePasswordComponent} from "./doc/forms/change-password/change-password.component";
+import {DefaultSimpleTaskViewComponent} from 'netgrif-components';
 
 @Injectable({
     providedIn: 'root'
@@ -91,6 +92,7 @@ export class NaeExampleAppViewService extends ViewService {
             {id: 'PublicTaskViewComponent', class: PublicTaskViewComponent},
             {id: 'PublicWorkflowViewComponent', class: PublicWorkflowViewComponent},
             {id: 'PublicResolverComponent', class: PublicResolverComponent},
+            {id: 'DefaultSimpleTaskViewComponent', class: DefaultSimpleTaskViewComponent},
             {
                 id: 'ResetPasswordFormComponent',
                 class: ResetPasswordFormComponent

--- a/projects/netgrif-components-core/src/lib/allowed-nets/services/factory/allowed-nets-service-factory.ts
+++ b/projects/netgrif-components-core/src/lib/allowed-nets/services/factory/allowed-nets-service-factory.ts
@@ -40,7 +40,10 @@ export function tabbedAllowedNetsServiceFactory(factory: AllowedNetsServiceFacto
  */
 export function navigationItemTaskAllowedNetsServiceFactory(factory: AllowedNetsServiceFactory,
                                                             baseAllowedNets: BaseAllowedNetsService,
-                                                            navigationItemTaskData: Array<DataGroup>): AllowedNetsService {
+                                                            navigationItemTaskData?: Array<DataGroup>): AllowedNetsService {
+    if (!navigationItemTaskData) {
+        return factory.createWithAllNets();
+    }
     const filterField = getFieldFromDataGroups(navigationItemTaskData, UserFilterConstants.FILTER_FIELD_ID) as FilterField;
     const allowedNetsField = getFieldFromDataGroups(navigationItemTaskData, UserFilterConstants.ALLOWED_NETS_FIELD_ID) as MultichoiceField;
 

--- a/projects/netgrif-components-core/src/lib/navigation/utility/filter-extraction.service.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/utility/filter-extraction.service.ts
@@ -51,17 +51,20 @@ export class FilterExtractionService {
         return navigationItemTaskAllowedNetsServiceFactory(this._factory, this.baseAllowedNets, sliced)
     }
 
-    public extractCompleteAdditionalFilterFromData(activatedRoute: ActivatedRoute, dataSection: Array<DataGroup>): Filter | undefined {
+    public extractCompleteAdditionalFilterFromData(dataSection: Array<DataGroup>, activatedRoute?: ActivatedRoute): Filter | undefined {
         const taskRefIndex = getFieldIndexFromDataGroups(dataSection, GroupNavigationConstants.ITEM_FIELD_ID_ADDITIONAL_FILTER_TASKREF);
         if (taskRefIndex === undefined) {
             return undefined;
         }
 
-        return this.extractCompleteFilterFromData(activatedRoute, dataSection.slice(taskRefIndex.dataGroupIndex + 1));
+        return this.extractCompleteFilterFromData(dataSection.slice(taskRefIndex.dataGroupIndex + 1), activatedRoute);
     }
 
-    public extractCompleteFilterFromData(activatedRoute: ActivatedRoute, dataSection?: Array<DataGroup>, fieldId: string = UserFilterConstants.FILTER_FIELD_ID): Filter | undefined {
+    public extractCompleteFilterFromData(dataSection?: Array<DataGroup>, activatedRoute?: ActivatedRoute, fieldId: string = UserFilterConstants.FILTER_FIELD_ID): Filter | undefined {
         if (!dataSection) {
+            if (!activatedRoute) {
+                throw new Error('ActivatedRoute not provided.');
+            }
             const singleCaseId = activatedRoute.snapshot.paramMap.get('singleCaseId');
             if (!singleCaseId) {
                 throw new Error('Case ID not found in route.');
@@ -83,7 +86,7 @@ export class FilterExtractionService {
             throw new Error('Filter segment could not be extracted from filter field');
         }
 
-        const parentFilter = this.extractCompleteFilterFromData(activatedRoute, dataSection.slice(filterIndex.dataGroupIndex + 1));
+        const parentFilter = this.extractCompleteFilterFromData(dataSection.slice(filterIndex.dataGroupIndex + 1), activatedRoute);
 
         if (parentFilter !== undefined && parentFilter.type === filterSegment.type) {
             return filterSegment.merge(parentFilter, MergeOperator.AND);

--- a/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
+++ b/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
@@ -7,6 +7,7 @@ import {ActivatedRoute} from '@angular/router';
 /**
  * Converts an {@link NAE_NAVIGATION_ITEM_TASK_DATA} injection token into {@link NAE_BASE_FILTER}
  * @param extractionService
+ * @param activatedRoute
  * @param navigationItemTaskData a navigation item task containing the aggregated data representing a navigation item
  */
 export function navigationItemTaskFilterFactory(extractionService: FilterExtractionService,

--- a/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
+++ b/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
@@ -2,6 +2,7 @@ import {BaseFilter} from '../search/models/base-filter';
 import {NAE_NAVIGATION_ITEM_TASK_DATA} from '../navigation/model/filter-case-injection-token';
 import {DataGroup} from '../resources/interface/data-groups';
 import {FilterExtractionService} from '../navigation/utility/filter-extraction.service';
+import {ActivatedRoute} from '@angular/router';
 
 /**
  * Converts an {@link NAE_NAVIGATION_ITEM_TASK_DATA} injection token into {@link NAE_BASE_FILTER}
@@ -9,8 +10,9 @@ import {FilterExtractionService} from '../navigation/utility/filter-extraction.s
  * @param navigationItemTaskData a navigation item task containing the aggregated data representing a navigation item
  */
 export function navigationItemTaskFilterFactory(extractionService: FilterExtractionService,
-                                                navigationItemTaskData: Array<DataGroup>): BaseFilter {
+                                                activatedRoute: ActivatedRoute,
+                                                navigationItemTaskData?: Array<DataGroup>): BaseFilter {
     return {
-        filter: extractionService.extractCompleteFilterFromData(navigationItemTaskData)
+        filter: extractionService.extractCompleteFilterFromData(activatedRoute, navigationItemTaskData)
     };
 }

--- a/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
+++ b/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
@@ -11,9 +11,9 @@ import {ActivatedRoute} from '@angular/router';
  * @param navigationItemTaskData a navigation item task containing the aggregated data representing a navigation item
  */
 export function navigationItemTaskFilterFactory(extractionService: FilterExtractionService,
-                                                activatedRoute: ActivatedRoute,
+                                                activatedRoute?: ActivatedRoute,
                                                 navigationItemTaskData?: Array<DataGroup>): BaseFilter {
     return {
-        filter: extractionService.extractCompleteFilterFromData(activatedRoute, navigationItemTaskData)
+        filter: extractionService.extractCompleteFilterFromData(navigationItemTaskData, activatedRoute)
     };
 }

--- a/projects/netgrif-components-core/src/lib/utility/navigation-item-task-search-categories-factory.ts
+++ b/projects/netgrif-components-core/src/lib/utility/navigation-item-task-search-categories-factory.ts
@@ -18,9 +18,12 @@ import {FilterType} from '../filter/models/filter-type';
  * field, if the filter metadata allow it and the filter is a task filter
  */
 export function navigationItemTaskCategoryFactory(categoryResolverService: CategoryResolverService,
-                                                  navigationItemTaskData: Array<DataGroup>,
-                                                  defaultCaseSearchCategories: Array<Type<Category<any>>>,
-                                                  defaultTaskSearchCategories: Array<Type<Category<any>>>): Array<Type<Category<any>>> {
+                                                  navigationItemTaskData?: Array<DataGroup>,
+                                                  defaultCaseSearchCategories?: Array<Type<Category<any>>>,
+                                                  defaultTaskSearchCategories?: Array<Type<Category<any>>>): Array<Type<Category<any>>> {
+    if (!navigationItemTaskData) {
+        return [];
+    }
     const filterField = getFieldFromDataGroups(navigationItemTaskData, UserFilterConstants.FILTER_FIELD_ID) as FilterField;
 
     if (filterField === undefined) {

--- a/projects/netgrif-components/src/lib/data-fields/enumeration-field/enumeration-caseref-field/enumeration-caseref-field.component.spec.ts
+++ b/projects/netgrif-components/src/lib/data-fields/enumeration-field/enumeration-caseref-field/enumeration-caseref-field.component.spec.ts
@@ -7,7 +7,7 @@ import {
     NAE_VIEW_ID_SEGMENT,
     OverflowService,
     TestMockDependenciesModule, UserFilterConstants
-} from 'netgrif-components-core';
+} from '@netgrif/components-core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterTestingModule} from '@angular/router/testing';
 import {of} from 'rxjs';

--- a/projects/netgrif-components/src/lib/data-fields/multichoice-field/multichoice-caseref-field/multichoice-caseref-field.component.spec.ts
+++ b/projects/netgrif-components/src/lib/data-fields/multichoice-field/multichoice-caseref-field/multichoice-caseref-field.component.spec.ts
@@ -7,7 +7,7 @@ import {
     NAE_VIEW_ID_SEGMENT,
     OverflowService,
     TestMockDependenciesModule, UserFilterConstants
-} from 'netgrif-components-core';
+} from '@netgrif/components-core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterTestingModule} from '@angular/router/testing';
 import {of} from 'rxjs';

--- a/projects/netgrif-components/src/lib/data-fields/task-ref-field/task-ref-list-field/task-ref-list-field.component.spec.ts
+++ b/projects/netgrif-components/src/lib/data-fields/task-ref-field/task-ref-list-field/task-ref-list-field.component.spec.ts
@@ -1,8 +1,8 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {TaskRefListFieldComponent} from './task-ref-list-field.component';
-import {Component} from "@angular/core";
-import {TaskRefField} from "netgrif-components-core";
+import {Component} from '@angular/core';
+import {TaskRefField} from '@netgrif/components-core';
 
 describe('TaskRefListFieldComponent', () => {
     let component: TaskRefListFieldComponent;

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-simple-task-view/default-simple-task-view.component.html
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-simple-task-view/default-simple-task-view.component.html
@@ -1,6 +1,6 @@
 <div class="task-tab-background full-height">
     <div fxLayout="column" fxLayoutAlign="start stretch" class="content-margin full-height" >
-        <div class="search-panel">
+        <div class="search-panel" *ngIf="searchEnabled">
             <nc-search class="search-width"></nc-search>
         </div>
         <nc-header #header type="task" class="task-panel-padding-mini"></nc-header>

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-simple-task-view/default-simple-task-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-simple-task-view/default-simple-task-view.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, Optional, ViewChild} from '@angular/core';
 import {
     SearchService,
     AllowedNetsService,
@@ -36,20 +36,20 @@ import {ActivatedRoute} from '@angular/router';
         {
             provide: NAE_BASE_FILTER,
             useFactory: navigationItemTaskFilterFactory,
-            deps: [FilterExtractionService, NAE_NAVIGATION_ITEM_TASK_DATA]
+            deps: [FilterExtractionService, ActivatedRoute, [new Optional(), NAE_NAVIGATION_ITEM_TASK_DATA]]
         },
         {
             provide: AllowedNetsService,
             useFactory: navigationItemTaskAllowedNetsServiceFactory,
-            deps: [AllowedNetsServiceFactory, BaseAllowedNetsService, NAE_NAVIGATION_ITEM_TASK_DATA]
+            deps: [AllowedNetsServiceFactory, BaseAllowedNetsService, [new Optional(), NAE_NAVIGATION_ITEM_TASK_DATA]]
         },
         {   provide: NAE_SEARCH_CATEGORIES,
             useFactory: navigationItemTaskCategoryFactory,
             deps: [
                 CategoryResolverService,
-                NAE_NAVIGATION_ITEM_TASK_DATA,
-                NAE_DEFAULT_CASE_SEARCH_CATEGORIES,
-                NAE_DEFAULT_TASK_SEARCH_CATEGORIES
+                [new Optional(), NAE_NAVIGATION_ITEM_TASK_DATA],
+                [new Optional(), NAE_DEFAULT_CASE_SEARCH_CATEGORIES],
+                [new Optional(), NAE_DEFAULT_TASK_SEARCH_CATEGORIES]
             ]
         },
     ]
@@ -58,8 +58,13 @@ export class DefaultSimpleTaskViewComponent extends AbstractTaskViewComponent im
 
     @ViewChild('header') public taskHeaderComponent: HeaderComponent;
 
-    constructor(taskViewService: TaskViewService) {
+    public searchEnabled: boolean = true;
+
+    constructor(taskViewService: TaskViewService, activatedRoute: ActivatedRoute) {
         super(taskViewService);
+        if (!!activatedRoute.snapshot.paramMap.get('singleCaseId')) {
+            this.searchEnabled = false;
+        }
     }
 
     ngAfterViewInit(): void {

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-tab-view/default-tab-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-tab-view/default-tab-view.component.ts
@@ -37,7 +37,8 @@ export class DefaultTabViewComponent {
 
     constructor(@Inject(NAE_NAVIGATION_ITEM_TASK_DATA) protected _navigationItemTaskData: Array<DataGroup>,
                 protected translationService: TranslateService,
-                protected extractionService: FilterExtractionService) {
+                protected extractionService: FilterExtractionService,
+                protected activatedRoute: ActivatedRoute) {
         const filter = extractFilterFromData(this._navigationItemTaskData);
         this.tabs = this.getTabs(filter.type);
     }
@@ -95,7 +96,7 @@ export class DefaultTabViewComponent {
         const taskViewHeadersMode = extractFieldValueFromData<string[]>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_TASK_HEADERS_MODE);
         const taskViewAllowTableMode = extractFieldValueFromData<boolean>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_TASK_ALLOW_TABLE_MODE);
         const taskViewDefaultHeadersMode = extractFieldValueFromData<string[]>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_TASK_DEFAULT_HEADERS_MODE);
-        const taskViewAdditionalFilter = this.extractionService.extractCompleteAdditionalFilterFromData(this._navigationItemTaskData);
+        const taskViewAdditionalFilter = this.extractionService.extractCompleteAdditionalFilterFromData(this.activatedRoute, this._navigationItemTaskData);
         const mergeWithBaseFilter = extractFieldValueFromData<boolean>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_MERGE_FILTERS);
         const additionalAllowedNets = this.extractionService.extractAdditionalFilterAllowedNets(this._navigationItemTaskData)?.allowedNetsIdentifiers;
 
@@ -146,7 +147,7 @@ export class DefaultTabViewComponent {
         }
         const showMoreMenu = extractFieldValueFromData<boolean>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_TASK_SHOW_MORE_MENU);
 
-        const filter = this.extractionService.extractCompleteFilterFromData(this._navigationItemTaskData);
+        const filter = this.extractionService.extractCompleteFilterFromData(this.activatedRoute, this._navigationItemTaskData);
         return [
             {
                 label: {text: labelData.name, icon: labelData.icon},

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-tab-view/default-tab-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-tab-view/default-tab-view.component.ts
@@ -96,7 +96,7 @@ export class DefaultTabViewComponent {
         const taskViewHeadersMode = extractFieldValueFromData<string[]>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_TASK_HEADERS_MODE);
         const taskViewAllowTableMode = extractFieldValueFromData<boolean>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_TASK_ALLOW_TABLE_MODE);
         const taskViewDefaultHeadersMode = extractFieldValueFromData<string[]>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_TASK_DEFAULT_HEADERS_MODE);
-        const taskViewAdditionalFilter = this.extractionService.extractCompleteAdditionalFilterFromData(this.activatedRoute, this._navigationItemTaskData);
+        const taskViewAdditionalFilter = this.extractionService.extractCompleteAdditionalFilterFromData(this._navigationItemTaskData, this.activatedRoute);
         const mergeWithBaseFilter = extractFieldValueFromData<boolean>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_MERGE_FILTERS);
         const additionalAllowedNets = this.extractionService.extractAdditionalFilterAllowedNets(this._navigationItemTaskData)?.allowedNetsIdentifiers;
 
@@ -147,7 +147,7 @@ export class DefaultTabViewComponent {
         }
         const showMoreMenu = extractFieldValueFromData<boolean>(this._navigationItemTaskData, GroupNavigationConstants.ITEM_FIELD_ID_TASK_SHOW_MORE_MENU);
 
-        const filter = this.extractionService.extractCompleteFilterFromData(this.activatedRoute, this._navigationItemTaskData);
+        const filter = this.extractionService.extractCompleteFilterFromData(this._navigationItemTaskData, this.activatedRoute);
         return [
             {
                 label: {text: labelData.name, icon: labelData.icon},

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-tabbed-case-view/default-tabbed-case-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-tabbed-case-view/default-tabbed-case-view.component.ts
@@ -38,6 +38,7 @@ import {
     filterCaseTabbedDataFilterFactory,
     filterCaseTabbedDataSearchCategoriesFactory
 } from '../model/factory-methods';
+import {ActivatedRoute} from '@angular/router';
 
 @Component({
     selector: 'nc-default-tabbed-case-view',
@@ -52,7 +53,7 @@ import {
         {
             provide: NAE_BASE_FILTER,
             useFactory: filterCaseTabbedDataFilterFactory,
-            deps: [FilterExtractionService, NAE_TAB_DATA]
+            deps: [FilterExtractionService, NAE_TAB_DATA, ActivatedRoute]
         },
         {
             provide: AllowedNetsService,

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-task-view/default-task-view.component.spec.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-task-view/default-task-view.component.spec.ts
@@ -1,10 +1,10 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {DefaultTaskViewComponent} from './default-task-view.component';
-import {NavigationComponentModule} from "../../../navigation.module";
-import {NAE_BASE_FILTER, NAE_VIEW_ID_SEGMENT, SimpleFilter, TestMockDependenciesModule} from "netgrif-components-core";
-import {NoopAnimationsModule} from "@angular/platform-browser/animations";
-import {RouterTestingModule} from "@angular/router/testing";
+import {NavigationComponentModule} from '../../../navigation.module';
+import {NAE_BASE_FILTER, NAE_VIEW_ID_SEGMENT, SimpleFilter, TestMockDependenciesModule} from '@netgrif/components-core';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {RouterTestingModule} from '@angular/router/testing';
 
 describe('DefaultTaskViewComponent', () => {
     let component: DefaultTaskViewComponent;

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/model/factory-methods.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/model/factory-methods.ts
@@ -10,15 +10,18 @@ import {
 } from '@netgrif/components-core';
 import {InjectedTabbedCaseViewDataWithNavigationItemTaskData} from './injected-tabbed-case-view-data-with-navigation-item-task-data';
 import {Type} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 
 /**
  * Converts a navigation item case task data injected by the {@link NAE_TAB_DATA} injection token into a {@link BaseFilter} instance
  * @param extractionService
  * @param tabData the injected data containing the navigation item case task data
+ * @param activatedRoute
  */
 export function filterCaseTabbedDataFilterFactory(extractionService: FilterExtractionService,
-                                                  tabData: InjectedTabbedCaseViewDataWithNavigationItemTaskData): BaseFilter {
-    return navigationItemTaskFilterFactory(extractionService, tabData.navigationItemTaskData);
+                                                  tabData: InjectedTabbedCaseViewDataWithNavigationItemTaskData,
+                                                  activatedRoute: ActivatedRoute): BaseFilter {
+    return navigationItemTaskFilterFactory(extractionService, activatedRoute, tabData.navigationItemTaskData);
 }
 
 /**


### PR DESCRIPTION
# Description

Implements possibility to navigate to task list view of case which caseId is included in URL. Only tasks of this case are displayed in this task list view. This view needs to be included in nae.json and registered in view.service of project. See example in code.

Implements [NAE-2036]

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually from application

| Name                | Tested on |
|---------------------| --------- |
| OS                  |     Linux Mint 21      |
| Runtime             |      Node 20.13.1     |
| Dependency Manager  |     npm 10.8.0      |
| Framework version   |    Angular 13.3.1      |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @Kovy95 @martinkranec 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [ ] User Guides
    - [x] Migration Guides


[NAE-2036]: https://netgrif.atlassian.net/browse/NAE-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ