### PR TITLE
[NAE-2048] Apply saved filter of advanced search in caseRef field

### DIFF
--- a/projects/netgrif-components-core/src/lib/navigation/utility/filter-extraction.service.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/utility/filter-extraction.service.ts
@@ -60,7 +60,8 @@ export class FilterExtractionService {
         return this.extractCompleteFilterFromData(dataSection.slice(taskRefIndex.dataGroupIndex + 1), activatedRoute);
     }
 
-    public extractCompleteFilterFromData(dataSection?: Array<DataGroup>, activatedRoute?: ActivatedRoute, fieldId: string = UserFilterConstants.FILTER_FIELD_ID): Filter | undefined {
+    public extractCompleteFilterFromData(dataSection?: Array<DataGroup>, activatedRoute?: ActivatedRoute, filterData?: Filter,
+                                         fieldId: string = UserFilterConstants.FILTER_FIELD_ID): Filter | undefined {
         if (!dataSection) {
             if (!activatedRoute) {
                 throw new Error('ActivatedRoute not provided.');
@@ -86,7 +87,11 @@ export class FilterExtractionService {
             throw new Error('Filter segment could not be extracted from filter field');
         }
 
-        const parentFilter = this.extractCompleteFilterFromData(dataSection.slice(filterIndex.dataGroupIndex + 1), activatedRoute);
+        if (!!filterData) {
+            filterSegment = filterSegment.merge(filterData, MergeOperator.AND);
+        }
+
+        const parentFilter = this.extractCompleteFilterFromData(dataSection.slice(filterIndex.dataGroupIndex + 1), activatedRoute, filterData);
 
         if (parentFilter !== undefined && parentFilter.type === filterSegment.type) {
             return filterSegment.merge(parentFilter, MergeOperator.AND);

--- a/projects/netgrif-components-core/src/lib/search/search-service/search.service.ts
+++ b/projects/netgrif-components-core/src/lib/search/search-service/search.service.ts
@@ -305,6 +305,14 @@ export class SearchService implements OnDestroy {
     }
 
     /**
+     * Loads whole new filter and search cases/tasks based on this filter
+     * @param newFilter whole new filter that should be used for search
+     */
+    public updateWithFullFilter(newFilter: Filter): void {
+        this._activeFilter.next(newFilter);
+    }
+
+    /**
      * @returns `undefined` if the predicate tree contains no complete query.
      * Otherwise returns the serialized form of the completed queries in the predicate tree.
      */

--- a/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
+++ b/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
@@ -1,19 +1,21 @@
 import {BaseFilter} from '../search/models/base-filter';
-import {NAE_NAVIGATION_ITEM_TASK_DATA} from '../navigation/model/filter-case-injection-token';
 import {DataGroup} from '../resources/interface/data-groups';
 import {FilterExtractionService} from '../navigation/utility/filter-extraction.service';
 import {ActivatedRoute} from '@angular/router';
+import {Filter} from '../filter/models/filter';
 
 /**
  * Converts an {@link NAE_NAVIGATION_ITEM_TASK_DATA} injection token into {@link NAE_BASE_FILTER}
  * @param extractionService
  * @param activatedRoute
  * @param navigationItemTaskData a navigation item task containing the aggregated data representing a navigation item
+ * @param filterData filter data to be used and combined in view
  */
 export function navigationItemTaskFilterFactory(extractionService: FilterExtractionService,
                                                 activatedRoute?: ActivatedRoute,
-                                                navigationItemTaskData?: Array<DataGroup>): BaseFilter {
+                                                navigationItemTaskData?: Array<DataGroup>,
+                                                filterData?: Filter): BaseFilter {
     return {
-        filter: extractionService.extractCompleteFilterFromData(navigationItemTaskData, activatedRoute)
+        filter: extractionService.extractCompleteFilterFromData(navigationItemTaskData, activatedRoute, filterData)
     };
 }

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/model/factory-methods.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/model/factory-methods.ts
@@ -21,7 +21,7 @@ import {ActivatedRoute} from '@angular/router';
 export function filterCaseTabbedDataFilterFactory(extractionService: FilterExtractionService,
                                                   tabData: InjectedTabbedCaseViewDataWithNavigationItemTaskData,
                                                   activatedRoute: ActivatedRoute): BaseFilter {
-    return navigationItemTaskFilterFactory(extractionService, activatedRoute, tabData.navigationItemTaskData);
+    return navigationItemTaskFilterFactory(extractionService, activatedRoute, tabData.navigationItemTaskData, tabData.loadFilter);
 }
 
 /**

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/refs/default-case-ref-list-view/default-case-ref-list-view.component.html
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/refs/default-case-ref-list-view/default-case-ref-list-view.component.html
@@ -3,7 +3,7 @@
     <div class="case-view-search-container">
         <div fxLayout="row" fxLayoutAlign="space-between">
             <div fxLayoutAlign="start center" fxFlex *ngIf="search">
-                <nc-search class="search-width" [disabled]="disabled()" [additionalFilterData]="additionalFilterData"></nc-search>
+                <nc-search class="search-width" [disabled]="disabled()" [additionalFilterData]="additionalFilterData" (filterLoaded)="loadFilter($event)"></nc-search>
             </div>
             <div fxLayoutAlign="end center" *ngIf="createCase">
                 <nc-create-case-button [disabled]="disabled()" [newCaseCreationConfig]="newCaseCreationConfig" (caseCreatedEvent)="createdCase($event)"></nc-create-case-button>

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/refs/default-case-ref-list-view/default-case-ref-list-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/refs/default-case-ref-list-view/default-case-ref-list-view.component.ts
@@ -3,23 +3,32 @@ import {
     AbstractCaseViewComponent,
     AllowedNetsService,
     AllowedNetsServiceFactory,
+    BaseFilter,
     Case,
+    CaseRefField,
     CaseViewService,
     CategoryFactory,
+    DATA_FIELD_PORTAL_DATA,
+    DataFieldPortalData,
     defaultCaseSearchCategoriesFactory,
+    EnumerationField,
+    Filter,
     FilterType,
+    MergeOperator,
+    MultichoiceField,
+    NAE_BASE_FILTER,
     NAE_CASE_REF_CREATE_CASE,
     NAE_CASE_REF_SEARCH,
-    CaseRefField,
     NAE_SEARCH_CATEGORIES,
     NAE_TAB_DATA,
     NAE_VIEW_ID_SEGMENT,
     OverflowService,
+    SavedFilterMetadata,
     SearchMode,
     SearchService,
     SimpleFilter,
     TaskSetDataRequestFields,
-    ViewIdService, DATA_FIELD_PORTAL_DATA, DataFieldPortalData, MultichoiceField, EnumerationField
+    ViewIdService
 } from '@netgrif/components-core';
 import {HeaderComponent} from '../../../../../header/header.component'
 import {DefaultTabbedTaskViewComponent} from '../../tabbed/default-tabbed-task-view/default-tabbed-task-view.component';
@@ -58,8 +67,12 @@ export class DefaultCaseRefListViewComponent extends AbstractCaseViewComponent i
     public search: boolean;
     public createCase: boolean;
 
+    private initFilter: Filter;
+
     constructor(caseViewService: CaseViewService,
+                protected searchService: SearchService,
                 @Optional() overflowService: OverflowService,
+                @Optional() @Inject(NAE_BASE_FILTER) protected _baseFilter: BaseFilter,
                 @Optional() @Inject(NAE_TAB_DATA) protected _injectedTabData: InjectedTabbedTaskViewDataWithNavigationItemTaskData,
                 @Optional() @Inject(DATA_FIELD_PORTAL_DATA) protected _dataFieldPortalData: DataFieldPortalData<MultichoiceField | CaseRefField | EnumerationField>,
                 @Optional() @Inject(NAE_CASE_REF_CREATE_CASE) protected _caseRefCreateCase: boolean = false,
@@ -70,6 +83,13 @@ export class DefaultCaseRefListViewComponent extends AbstractCaseViewComponent i
         });
         this.search = !!_caseRefSearch;
         this.createCase = !!_caseRefCreateCase;
+        if (this._baseFilter.filter instanceof Filter) {
+            this.initFilter = this._baseFilter.filter
+        } else {
+            this._baseFilter.filter.subscribe(observableFilter => {
+                this.initFilter = observableFilter;
+            });
+        }
     }
 
     ngAfterViewInit(): void {
@@ -119,5 +139,9 @@ export class DefaultCaseRefListViewComponent extends AbstractCaseViewComponent i
 
     createdCase(caze: Case) {
         this.handleCaseClick(caze);
+    }
+
+    loadFilter(filterData: SavedFilterMetadata) {
+        this.searchService.updateWithFullFilter(this.initFilter.merge(filterData.filter, MergeOperator.AND));
     }
 }

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/refs/default-case-ref-list-view/default-case-ref-list-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/refs/default-case-ref-list-view/default-case-ref-list-view.component.ts
@@ -83,6 +83,9 @@ export class DefaultCaseRefListViewComponent extends AbstractCaseViewComponent i
         });
         this.search = !!_caseRefSearch;
         this.createCase = !!_caseRefCreateCase;
+        if (!this._baseFilter || !this._baseFilter.filter) {
+            return;
+        }
         if (this._baseFilter.filter instanceof Filter) {
             this.initFilter = this._baseFilter.filter
         } else {

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/tabbed/default-tabbed-case-view/default-tabbed-case-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/tabbed/default-tabbed-case-view/default-tabbed-case-view.component.ts
@@ -121,7 +121,7 @@ export class DefaultTabbedCaseViewComponent extends AbstractTabbedCaseViewCompon
             },
             canBeClosed: true,
             tabContentComponent: DefaultTabbedCaseViewComponent,
-            injectedObject: {...this._injectedTabData, filterCase: filterData.filterCase},
+            injectedObject: {...this._injectedTabData, loadFilter: filterData.filter},
             order: this._injectedTabData.tabViewOrder,
             parentUniqueId: this._injectedTabData.tabUniqueId
         }, this._autoswitchToTaskTab, this._openExistingTab);


### PR DESCRIPTION
# Description

Implements option to load filter from advanced search for caseRef component fields:
    - caseRef field default view
    - multichoice caseref component view
    - enumeration caseref component view

Fix loading of filters in default-tabbed-view.

Implements [NAE-2048] 

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually from application

| Name                | Tested on |
|---------------------| --------- |
| OS                  |     Linux Mint 21      |
| Runtime             |      Node 20.13.1      |
| Dependency Manager  |    npm  10.8.0    |
| Framework version   |    Angular 13.3.1       |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mazarijuraj @RudeBoyxX 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [ ] User Guides
    - [x] Migration Guides



[NAE-2048]: https://netgrif.atlassian.net/browse/NAE-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ