### PR TITLE
[NAE-2056] Fix NAE-2048 in release 6.4.1

### DIFF
--- a/projects/netgrif-components-core/src/lib/navigation/utility/filter-extraction.service.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/utility/filter-extraction.service.ts
@@ -58,7 +58,7 @@ export class FilterExtractionService {
         return this.extractCompleteFilterFromData(dataSection.slice(taskRefIndex.dataGroupIndex + 1));
     }
 
-    public extractCompleteFilterFromData(dataSection: Array<DataGroup>, fieldId: string = UserFilterConstants.FILTER_FIELD_ID): Filter | undefined {
+    public extractCompleteFilterFromData(dataSection?: Array<DataGroup>, filterData?: Filter, fieldId: string = UserFilterConstants.FILTER_FIELD_ID): Filter | undefined {
         const filterIndex = getFieldIndexFromDataGroups(dataSection, fieldId);
 
         if (filterIndex === undefined) {
@@ -74,7 +74,11 @@ export class FilterExtractionService {
             throw new Error('Filter segment could not be extracted from filter field');
         }
 
-        const parentFilter = this.extractCompleteFilterFromData(dataSection.slice(filterIndex.dataGroupIndex + 1));
+        if (!!filterData) {
+            filterSegment = filterSegment.merge(filterData, MergeOperator.AND);
+        }
+
+        const parentFilter = this.extractCompleteFilterFromData(dataSection.slice(filterIndex.dataGroupIndex + 1), filterData);
 
         if (parentFilter !== undefined && parentFilter.type === filterSegment.type) {
             return filterSegment.merge(parentFilter, MergeOperator.AND);

--- a/projects/netgrif-components-core/src/lib/search/search-service/search.service.ts
+++ b/projects/netgrif-components-core/src/lib/search/search-service/search.service.ts
@@ -305,6 +305,14 @@ export class SearchService implements OnDestroy {
     }
 
     /**
+     * Loads whole new filter and search cases/tasks based on this filter
+     * @param newFilter whole new filter that should be used for search
+     */
+    public updateWithFullFilter(newFilter: Filter): void {
+        this._activeFilter.next(newFilter);
+    }
+
+    /**
      * @returns `undefined` if the predicate tree contains no complete query.
      * Otherwise returns the serialized form of the completed queries in the predicate tree.
      */

--- a/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
+++ b/projects/netgrif-components-core/src/lib/utility/navigation-item-task-filter-factory.ts
@@ -1,7 +1,8 @@
 import {BaseFilter} from '../search/models/base-filter';
-import {NAE_NAVIGATION_ITEM_TASK_DATA} from '../navigation/model/filter-case-injection-token';
 import {DataGroup} from '../resources/interface/data-groups';
+import {NAE_NAVIGATION_ITEM_TASK_DATA} from '../navigation/model/filter-case-injection-token';
 import {FilterExtractionService} from '../navigation/utility/filter-extraction.service';
+import {Filter} from '../filter/models/filter';
 
 /**
  * Converts an {@link NAE_NAVIGATION_ITEM_TASK_DATA} injection token into {@link NAE_BASE_FILTER}
@@ -9,8 +10,9 @@ import {FilterExtractionService} from '../navigation/utility/filter-extraction.s
  * @param navigationItemTaskData a navigation item task containing the aggregated data representing a navigation item
  */
 export function navigationItemTaskFilterFactory(extractionService: FilterExtractionService,
-                                                navigationItemTaskData: Array<DataGroup>): BaseFilter {
+                                                navigationItemTaskData: Array<DataGroup>,
+                                                filterData?: Filter): BaseFilter {
     return {
-        filter: extractionService.extractCompleteFilterFromData(navigationItemTaskData)
+        filter: extractionService.extractCompleteFilterFromData(navigationItemTaskData, filterData)
     };
 }

--- a/projects/netgrif-components/src/lib/data-fields/file-field/file-default-field/file-default-field.component.html
+++ b/projects/netgrif-components/src/lib/data-fields/file-field/file-default-field/file-default-field.component.html
@@ -52,7 +52,7 @@
                     'border-color': getPreviewBorderColor()
                  }"
              [ngClass]="{'border-LGBTQ': isBorderLGBTQ(), 'border-default': isBorderDefault()}"
-             [src]="previewSource" alt="Image preview" (click)="showPreviewDialog()"/>
+             [src]="previewSource" alt="Image preview" (click)="showPreviewDialog()" loading="lazy"/>
         <mat-spinner *ngIf="previewSource === undefined && !!state.downloading && isDisplayable"
                      [diameter]="26"></mat-spinner>
     </div>

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-case-ref-list-view/default-case-ref-list-view.component.html
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-case-ref-list-view/default-case-ref-list-view.component.html
@@ -3,7 +3,7 @@
     <div class="case-view-search-container">
         <div fxLayout="row" fxLayoutAlign="space-between">
             <div fxLayoutAlign="start center" fxFlex *ngIf="search">
-                <nc-search class="search-width" [disabled]="disabled()" [additionalFilterData]="additionalFilterData"></nc-search>
+                <nc-search class="search-width" [disabled]="disabled()" [additionalFilterData]="additionalFilterData" (filterLoaded)="loadFilter($event)"></nc-search>
             </div>
             <div fxLayoutAlign="end center" *ngIf="createCase">
                 <nc-create-case-button [disabled]="disabled()" [newCaseCreationConfig]="newCaseCreationConfig" (caseCreatedEvent)="createdCase($event)"></nc-create-case-button>

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-case-ref-list-view/default-case-ref-list-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-case-ref-list-view/default-case-ref-list-view.component.ts
@@ -3,23 +3,32 @@ import {
     AbstractCaseViewComponent,
     AllowedNetsService,
     AllowedNetsServiceFactory,
+    BaseFilter,
     Case,
+    CaseRefField,
     CaseViewService,
     CategoryFactory,
+    DATA_FIELD_PORTAL_DATA,
+    DataFieldPortalData,
     defaultCaseSearchCategoriesFactory,
+    EnumerationField,
+    Filter,
     FilterType,
+    MergeOperator,
+    MultichoiceField,
+    NAE_BASE_FILTER,
     NAE_CASE_REF_CREATE_CASE,
     NAE_CASE_REF_SEARCH,
-    CaseRefField,
     NAE_SEARCH_CATEGORIES,
     NAE_TAB_DATA,
     NAE_VIEW_ID_SEGMENT,
     OverflowService,
+    SavedFilterMetadata,
     SearchMode,
     SearchService,
     SimpleFilter,
     TaskSetDataRequestFields,
-    ViewIdService, DATA_FIELD_PORTAL_DATA, DataFieldPortalData, MultichoiceField, EnumerationField
+    ViewIdService
 } from '@netgrif/components-core';
 import {HeaderComponent} from '../../../../header/header.component'
 import {DefaultTabbedTaskViewComponent} from '../default-tabbed-task-view/default-tabbed-task-view.component';
@@ -58,8 +67,12 @@ export class DefaultCaseRefListViewComponent extends AbstractCaseViewComponent i
     public search: boolean;
     public createCase: boolean;
 
+    private initFilter: Filter;
+
     constructor(caseViewService: CaseViewService,
+                protected searchService: SearchService,
                 @Optional() overflowService: OverflowService,
+                @Optional() @Inject(NAE_BASE_FILTER) protected _baseFilter: BaseFilter,
                 @Optional() @Inject(NAE_TAB_DATA) protected _injectedTabData: InjectedTabbedTaskViewDataWithNavigationItemTaskData,
                 @Optional() @Inject(DATA_FIELD_PORTAL_DATA) protected _dataFieldPortalData: DataFieldPortalData<MultichoiceField | CaseRefField | EnumerationField>,
                 @Optional() @Inject(NAE_CASE_REF_CREATE_CASE) protected _caseRefCreateCase: boolean = false,
@@ -70,6 +83,13 @@ export class DefaultCaseRefListViewComponent extends AbstractCaseViewComponent i
         });
         this.search = !!_caseRefSearch;
         this.createCase = !!_caseRefCreateCase;
+        if (this._baseFilter.filter instanceof Filter) {
+            this.initFilter = this._baseFilter.filter
+        } else {
+            this._baseFilter.filter.subscribe(observableFilter => {
+                this.initFilter = observableFilter;
+            });
+        }
     }
 
     ngAfterViewInit(): void {
@@ -119,5 +139,9 @@ export class DefaultCaseRefListViewComponent extends AbstractCaseViewComponent i
 
     createdCase(caze: Case) {
         this.handleCaseClick(caze);
+    }
+
+    loadFilter(filterData: SavedFilterMetadata) {
+        this.searchService.updateWithFullFilter(this.initFilter.merge(filterData.filter, MergeOperator.AND));
     }
 }

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-case-ref-list-view/default-case-ref-list-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-case-ref-list-view/default-case-ref-list-view.component.ts
@@ -83,6 +83,9 @@ export class DefaultCaseRefListViewComponent extends AbstractCaseViewComponent i
         });
         this.search = !!_caseRefSearch;
         this.createCase = !!_caseRefCreateCase;
+        if (!this._baseFilter || !this._baseFilter.filter) {
+            return;
+        }
         if (this._baseFilter.filter instanceof Filter) {
             this.initFilter = this._baseFilter.filter
         } else {

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-tabbed-case-view/default-tabbed-case-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/default-tabbed-case-view/default-tabbed-case-view.component.ts
@@ -120,7 +120,7 @@ export class DefaultTabbedCaseViewComponent extends AbstractTabbedCaseViewCompon
             },
             canBeClosed: true,
             tabContentComponent: DefaultTabbedCaseViewComponent,
-            injectedObject: {...this._injectedTabData, filterCase: filterData.filterCase},
+            injectedObject: {...this._injectedTabData, loadFilter: filterData.filter},
             order: this._injectedTabData.tabViewOrder,
             parentUniqueId: this._injectedTabData.tabUniqueId
         }, this._autoswitchToTaskTab, this._openExistingTab);

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/model/factory-methods.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/model/factory-methods.ts
@@ -18,7 +18,7 @@ import {Type} from '@angular/core';
  */
 export function filterCaseTabbedDataFilterFactory(extractionService: FilterExtractionService,
                                                   tabData: InjectedTabbedCaseViewDataWithNavigationItemTaskData): BaseFilter {
-    return navigationItemTaskFilterFactory(extractionService, tabData.navigationItemTaskData);
+    return navigationItemTaskFilterFactory(extractionService, tabData.navigationItemTaskData, tabData.loadFilter);
 }
 
 /**


### PR DESCRIPTION
# Description

Implements option to load filter from advanced search for caseRef component fields:
    - caseRef field default view
    - multichoice caseref component view
    - enumeration caseref component view

Fix loading of filters in default-tabbed-view.

Implementation for release 6.4.1

Implements [NAE-2056] 

## Dependencies

No new dependencies were introduced.

### Third party dependencies

No new dependencies were introduced.

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually from application

| Name                | Tested on |
|---------------------| --------- |
| OS                  |     Linux Mint 21      |
| Runtime             |      Node 20.13.1      |
| Dependency Manager  |    npm  10.8.0    |
| Framework version   |    Angular 13.3.1       |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @mazarijuraj @RudeBoyxX 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [ ] User Guides
    - [x] Migration Guides


[NAE-2056]: https://netgrif.atlassian.net/browse/NAE-2056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ