### PR TITLE
Refactor case ID usage to replace `stringId` with `id`

### DIFF
--- a/projects/netgrif-components-core/src/lib/data-fields/case-ref-field/model/abstract-case-ref-base-field-component.ts
+++ b/projects/netgrif-components-core/src/lib/data-fields/case-ref-field/model/abstract-case-ref-base-field-component.ts
@@ -42,7 +42,7 @@ export abstract class AbstractCaseRefBaseFieldComponent<T extends DataField<unkn
             },
             {
                 provide: NAE_BASE_FILTER,
-                useValue: { filter: SimpleFilter.fromCaseQuery((filterProperty && query ? query : {stringId: filterValue})) } as BaseFilter
+                useValue: { filter: SimpleFilter.fromCaseQuery((filterProperty && query ? query : {id: filterValue})) } as BaseFilter
             },
             {
                 provide: NAE_VIEW_ID_SEGMENT,

--- a/projects/netgrif-components-core/src/lib/filter/models/case-search-request-body.ts
+++ b/projects/netgrif-components-core/src/lib/filter/models/case-search-request-body.ts
@@ -56,6 +56,10 @@ export interface CaseSearchRequestBody {
      * Returned cases must have the specified string ID.
      * If more than one string ID is specified, the returned cases must have one of them.
      */
+    id?: string | Array<string>;
+    /**
+     * @deprecated
+     */
     stringId?: string | Array<string>;
     /**
      * Returned cases must be instances of processes of the group with the specified ID.

--- a/projects/netgrif-components-core/src/lib/groups/services/next-group.service.ts
+++ b/projects/netgrif-components-core/src/lib/groups/services/next-group.service.ts
@@ -40,7 +40,7 @@ export class NextGroupService implements OnDestroy {
                 const params = new HttpParams();
                 params.set(PaginationParams.PAGE_SIZE, `${(user as any).nextGroups.length}`);
 
-                return this._caseResourceService.searchCases(SimpleFilter.fromCaseQuery({stringId: (user as any).nextGroups}), params)
+                return this._caseResourceService.searchCases(SimpleFilter.fromCaseQuery({id: (user as any).nextGroups}), params)
                     .pipe(
                         map(page => page.content ? page.content : []),
                         map(groups => groups.filter(group => group.author.fullName !== 'application engine'))

--- a/projects/netgrif-components-core/src/lib/navigation/dashboard/abstract-dashboard.component.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/dashboard/abstract-dashboard.component.ts
@@ -156,7 +156,7 @@ export abstract class AbstractDashboardComponent {
     }, dashboardItemsParams: HttpParams) {
         const itemsOrder = this.getManagementItemsOrder(this.dashboardCase)?.split(",");
         let dashboardItemsSearchBody: CaseSearchRequestBody = {
-            stringId: Object.keys(dashboardItemsOptions)
+            id: Object.keys(dashboardItemsOptions)
         };
         this._caseResource.searchCases(SimpleFilter.fromCaseQuery(dashboardItemsSearchBody), dashboardItemsParams).subscribe(resultItems => {
             const itemsContent = resultItems.content;

--- a/projects/netgrif-components-core/src/lib/navigation/navigation-double-drawer/service/double-drawer-navigation.service.ts
+++ b/projects/netgrif-components-core/src/lib/navigation/navigation-double-drawer/service/double-drawer-navigation.service.ts
@@ -462,7 +462,7 @@ export class DoubleDrawerNavigationService implements OnDestroy {
 
     protected getItemCasesByIds(caseIds: string[], pageNumber: number, pageSize: string | number): Observable<Page<Case>> {
         const searchBody: CaseSearchRequestBody = {
-            stringId: caseIds,
+            id: caseIds,
             process: MENU_IDENTIFIERS.map(id => ({identifier: id} as PetriNetSearchRequest)),
         };
 

--- a/projects/netgrif-components-core/src/lib/view/tree-case-view/tree-component/case-tree.service.spec.ts
+++ b/projects/netgrif-components-core/src/lib/view/tree-case-view/tree-component/case-tree.service.spec.ts
@@ -91,7 +91,7 @@ describe('CaseTreeService', () => {
             }
         });
 
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     it('should initialize with root node hidden', (done) => {
@@ -108,7 +108,7 @@ describe('CaseTreeService', () => {
             }
         });
 
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     it('should initialize lazy-loaded tree with root node shown', (done) => {
@@ -137,7 +137,7 @@ describe('CaseTreeService', () => {
             }
         });
 
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     it('should initialize lazy-loaded tree with root node hidden', (done) => {
@@ -168,7 +168,7 @@ describe('CaseTreeService', () => {
             }
         });
 
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     it('should initialize eager-loaded tree with root node shown', (done) => {
@@ -210,7 +210,7 @@ describe('CaseTreeService', () => {
         });
 
         treeService.isEagerLoaded = true;
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     it('should initialize eager-loaded tree with root node hidden', (done) => {
@@ -250,7 +250,7 @@ describe('CaseTreeService', () => {
         });
 
         treeService.isEagerLoaded = true;
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     it('should add root child with root node shown', (done) => {
@@ -281,7 +281,7 @@ describe('CaseTreeService', () => {
             }
         });
 
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     it('should add root child with root node hidden', (done) => {
@@ -307,7 +307,7 @@ describe('CaseTreeService', () => {
             }
         });
 
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     // NAE-1185
@@ -346,7 +346,7 @@ describe('CaseTreeService', () => {
         });
 
         treeService.isEagerLoaded = true;
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 
     // NAE-1185 similar to the reported bug but in combination with changed fields response adding multiple sibling branches
@@ -395,7 +395,7 @@ describe('CaseTreeService', () => {
         });
 
         treeService.isEagerLoaded = true;
-        treeService.rootFilter = SimpleFilter.fromCaseQuery({stringId: 'root'});
+        treeService.rootFilter = SimpleFilter.fromCaseQuery({id: 'root'});
     });
 });
 
@@ -452,11 +452,11 @@ class TreeTestCaseResourceService {
     public searchCases(filter: Filter, params?: Params): Observable<Page<Case>> {
         if (filter.type === FilterType.CASE
             && !Array.isArray(filter.getRequestBody())
-            && (filter.getRequestBody() as CaseSearchRequestBody).stringId
-            && !Array.isArray((filter.getRequestBody() as CaseSearchRequestBody).stringId)) {
+            && (filter.getRequestBody() as CaseSearchRequestBody).id
+            && !Array.isArray((filter.getRequestBody() as CaseSearchRequestBody).id)) {
             const content: Array<Case> = [];
-            if (this.mockCases.has((filter.getRequestBody() as CaseSearchRequestBody).stringId as string)) {
-                content.push(this.mockCases.get((filter.getRequestBody() as CaseSearchRequestBody).stringId as string));
+            if (this.mockCases.has((filter.getRequestBody() as CaseSearchRequestBody).id as string)) {
+                content.push(this.mockCases.get((filter.getRequestBody() as CaseSearchRequestBody).id as string));
             }
             return of(createMockPage(content));
         } else {


### PR DESCRIPTION
# Description

Replaced all occurrences of `stringId` with `id` across the codebase for consistency in case filtering and retrieval. Marked `stringId` as deprecated in the `CaseSearchRequestBody` model. Updated relevant services, components, and tests to ensure functionality remains intact.

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

This was tested manually and with unit tests.

### Test Configuration

| Name                | Tested on          |
| ------------------- | ------------------ |
| OS                  | macOS Sequoia 15.0 |
| Runtime             | Node 20.17.0       |
| Dependency Manager  | NPM 10.8.2         |
| Framework version   | Angular 13.3.1     |
| Run parameters      |                    |
| Other configuration |                    |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides
