### PR TITLE
[NAE-2224] Title in optional text in case creation button as I18nString

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netgrif/components-project",
-    "version": "7.0.0-rc.11",
+    "version": "7.0.0-rc.12",
     "description": "Netgrif Application Engine Frontend project. Project includes angular libraries as base for NAE applications.",
     "homepage": "https://components.netgrif.com",
     "license": "SEE LICENSE IN LICENSE",

--- a/projects/nae-example-app/src/app/doc/case-view/case-view.component.ts
+++ b/projects/nae-example-app/src/app/doc/case-view/case-view.component.ts
@@ -59,7 +59,9 @@ export class CaseViewComponent extends AbstractCaseViewComponent implements Afte
             enableCaseTitle: true,
             isCaseTitleRequired: false,
             newCaseButtonConfig: {
-                createCaseButtonTitle: 'test',
+                createCaseButtonTitle: {
+                    defaultValue: 'test'
+                },
                 createCaseButtonIcon: 'home'
             }
         });

--- a/projects/netgrif-components-core/package.json
+++ b/projects/netgrif-components-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netgrif/components-core",
-    "version": "7.0.0-rc.11",
+    "version": "7.0.0-rc.12",
     "description": "Netgrif Application engine frontend core Angular library",
     "homepage": "https://components.netgrif.com",
     "license": "SEE LICENSE IN LICENSE",

--- a/projects/netgrif-components-core/src/lib/side-menu/content-components/new-case/model/new-case-injection-data.ts
+++ b/projects/netgrif-components-core/src/lib/side-menu/content-components/new-case/model/new-case-injection-data.ts
@@ -2,6 +2,7 @@ import {SideMenuInjectionData} from '../../../models/side-menu-injection-data';
 import {Observable} from 'rxjs';
 import {PetriNetReference} from '../../../../resources/interface/petri-net-reference';
 import {InjectionToken} from '@angular/core';
+import {I18nFieldValue} from "../../../../data-fields/i18n-field/models/i18n-field-value";
 
 export interface NewCaseInjectionData extends SideMenuInjectionData {
     allowedNets$: Observable<Array<PetriNetReference>>;
@@ -26,7 +27,7 @@ export interface NewCaseCreationConfigurationData {
 
 export interface NewCaseButtonConfiguration {
 
-    createCaseButtonTitle?: string;
+    createCaseButtonTitle?: I18nFieldValue;
 
     createCaseButtonIcon?: string;
 

--- a/projects/netgrif-components/package.json
+++ b/projects/netgrif-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netgrif/components",
-    "version": "7.0.0-rc.11",
+    "version": "7.0.0-rc.12",
     "description": "Netgrif Application Engine frontend Angular components",
     "homepage": "https://components.netgrif.com",
     "license": "SEE LICENSE IN LICENSE",
@@ -29,7 +29,7 @@
         "nae frontend"
     ],
     "peerDependencies": {
-        "@netgrif/components-core": "7.0.0-rc.11",
+        "@netgrif/components-core": "7.0.0-rc.12",
         "@angular-material-components/datetime-picker": "~16.0.0",
         "@angular-material-components/moment-adapter": "~16.0.0",
         "@angular/animations": "~17.1.0",

--- a/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/tabbed/default-tab-view/default-tab-view.component.ts
+++ b/projects/netgrif-components/src/lib/navigation/group-navigation-component-resolver/default-components/tabbed/default-tab-view/default-tab-view.component.ts
@@ -14,7 +14,8 @@ import {
     ViewIdService,
     FilterExtractionService,
     GroupNavigationConstants,
-    hasView
+    hasView,
+    I18nFieldValue
 } from '@netgrif/components-core';
 import {DefaultTabbedCaseViewComponent} from '../default-tabbed-case-view/default-tabbed-case-view.component';
 import {DefaultTabbedTaskViewComponent} from '../default-tabbed-task-view/default-tabbed-task-view.component';
@@ -67,7 +68,7 @@ export class DefaultTabViewComponent {
 
         const blockNetsString = extractFieldValueFromData<string>(viewDataGroups, GroupNavigationConstants.ITEM_FIELD_ID_CASE_BANNED_PROCESS_CREATION);
         const blockNets = blockNetsString === undefined ? [] : blockNetsString.split(',')
-        const createCaseButtonTitle: string = extractFieldValueFromData<string>(viewDataGroups, GroupNavigationConstants.ITEM_FIELD_ID_CREATE_CASE_BUTTON_TITLE);
+        const createCaseButtonTitle: I18nFieldValue = extractFieldValueFromData<I18nFieldValue>(viewDataGroups, GroupNavigationConstants.ITEM_FIELD_ID_CREATE_CASE_BUTTON_TITLE);
         const createCaseButtonIcon: string = extractFieldValueFromData<string>(viewDataGroups, GroupNavigationConstants.ITEM_FIELD_ID_CREATE_CASE_BUTTON_ICON);
         const requireTitle: boolean = extractFieldValueFromData<boolean>(viewDataGroups, GroupNavigationConstants.ITEM_FIELD_ID_CASE_TITLE_IN_CREATION);
         const showCreateCaseButton: boolean = extractFieldValueFromData<boolean>(viewDataGroups, GroupNavigationConstants.ITEM_FIELD_ID_SHOW_CREATE_CASE_BUTTON);

--- a/projects/netgrif-components/src/lib/view/case-view/components/create-case-button/create-case-button.component.ts
+++ b/projects/netgrif-components/src/lib/view/case-view/components/create-case-button/create-case-button.component.ts
@@ -8,6 +8,7 @@ import {
     LoadingEmitter
 } from '@netgrif/components-core';
 import {map} from "rxjs/operators";
+import {TranslateService} from '@ngx-translate/core';
 
 @Component({
     selector: 'nc-create-case-button',
@@ -24,7 +25,8 @@ export class CreateCaseButtonComponent implements OnInit {
     protected _resolvedCaseButtonIcon: string;
     protected _loading: LoadingEmitter;
 
-    constructor(protected _caseViewService: CaseViewService) {
+    constructor(protected _caseViewService: CaseViewService,
+                protected _translateService: TranslateService) {
         this._loading = new LoadingEmitter();
     }
 
@@ -44,8 +46,18 @@ export class CreateCaseButtonComponent implements OnInit {
         const config: NewCaseButtonConfiguration = this.newCaseCreationConfig['newCaseButtonConfig'];
         if (!!config) {
             this._resolvedCaseButtonIcon = config.createCaseButtonIcon;
-            this._resolvedCaseButtonTitle = config.createCaseButtonTitle;
+            this._resolvedCaseButtonTitle = this.resolveTranslation(config);
         }
+    }
+
+    public resolveTranslation(config: NewCaseButtonConfiguration): string {
+        const locale = this._translateService.currentLang;
+        if(!config.createCaseButtonTitle.defaultValue && !config.createCaseButtonTitle.translations) {
+            return "";
+        }
+        return locale in config.createCaseButtonTitle.translations
+            ? config.createCaseButtonTitle.translations[locale]
+            : config.createCaseButtonTitle.defaultValue;
     }
 
     public shouldShowCreateButton(): Observable<boolean> {
@@ -67,7 +79,8 @@ export class CreateCaseButtonComponent implements OnInit {
             if (this._caseViewService.viewEnabled(kaze)) {
                 this.caseCreatedEvent.next(kaze);
             }
-        }, error => {},() => this._loading.off());
+        }, error => {
+        }, () => this._loading.off());
 
         return myCase;
     }


### PR DESCRIPTION
# Description

- updated `createCaseButtonTitle` to use `I18nFieldValue` for internationalization
- added translation resolution in `CreateCaseButtonComponent`
- adjusted related interfaces and usage in components

Implements [NAE-2224](https://netgrif.atlassian.net/browse/NAE-2224)

## How Has Been This Tested?

manually


### Test Configuration


### Test Configuration
| Name                | Tested on |
|---------------------| --------- |
| OS                  |     windows 10      |
| Runtime             |    Node 20.19.0       |
| Dependency Manager  |   NPM 10.8.2       |
| Framework version   |   Angular 19.2.2    |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[NAE-2224]: https://netgrif.atlassian.net/browse/NAE-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - “Create case” button titles are now fully translatable and resolved per user language with a fallback to a provided default.
  - Localization applies across case views (including tabbed views) for consistent translated labels without changing visibility or behavior of the button.

- Chores
  - Package versions bumped to 7.0.0-rc.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->