### PR TITLE
[ETASK-29] Menu item creation in menu

### DIFF
--- a/projects/netgrif-components-core/src/lib/task/services/assign-task.service.ts
+++ b/projects/netgrif-components-core/src/lib/task/services/assign-task.service.ts
@@ -24,8 +24,8 @@ import {ChangedFieldsService} from '../../changed-fields/services/changed-fields
 import {EventService} from '../../event/services/event.service';
 import {ChangedFieldsMap} from '../../event/services/interfaces/changed-fields-map';
 import {TaskEventOutcome} from '../../event/model/event-outcomes/task-outcomes/task-event-outcome';
-import {FrontActionService} from "../../actions/services/front-action.service";
-import {FrontAction} from "../../data-fields/models/changed-fields";
+import {FrontActionService} from '../../actions/services/front-action.service';
+import {FrontAction} from '../../data-fields/models/changed-fields';
 
 
 /**

--- a/projects/netgrif-components-core/src/lib/task/services/assign-task.service.ts
+++ b/projects/netgrif-components-core/src/lib/task/services/assign-task.service.ts
@@ -24,6 +24,8 @@ import {ChangedFieldsService} from '../../changed-fields/services/changed-fields
 import {EventService} from '../../event/services/event.service';
 import {ChangedFieldsMap} from '../../event/services/interfaces/changed-fields-map';
 import {TaskEventOutcome} from '../../event/model/event-outcomes/task-outcomes/task-event-outcome';
+import {FrontActionService} from "../../actions/services/front-action.service";
+import {FrontAction} from "../../data-fields/models/changed-fields";
 
 
 /**
@@ -41,6 +43,7 @@ export class AssignTaskService extends TaskHandlingService {
                 protected _taskDataService: TaskDataService,
                 protected _eventQueue: EventQueueService,
                 protected _eventService: EventService,
+                protected _frontActionService: FrontActionService,
                 protected _changedFieldsService: ChangedFieldsService,
                 @Inject(NAE_TASK_OPERATIONS) protected _taskOperations: TaskOperations,
                 @Optional() _selectedCaseService: SelectedCaseService,
@@ -123,6 +126,10 @@ export class AssignTaskService extends TaskHandlingService {
                         .parseChangedFieldsFromOutcomeTree(outcomeResource.outcome);
                     if (!!changedFieldsMap) {
                         this._changedFieldsService.emitChangedFields(changedFieldsMap);
+                    }
+                    const frontActions: Array<FrontAction> = this._eventService.parseFrontActionsFromOutcomeTree(outcomeResource.outcome);
+                    if (frontActions?.length > 0) {
+                        this._frontActionService.runAll(frontActions);
                     }
                     forceReload ? this._taskOperations.forceReload() : this._taskOperations.reload();
                     this.completeActions(afterAction, nextEvent, true, outcomeResource.outcome as AssignTaskEventOutcome);

--- a/projects/netgrif-components-core/src/lib/task/services/cancel-task.service.ts
+++ b/projects/netgrif-components-core/src/lib/task/services/cancel-task.service.ts
@@ -26,6 +26,8 @@ import {ChangedFieldsService} from '../../changed-fields/services/changed-fields
 import { EventService} from '../../event/services/event.service';
 import {ChangedFieldsMap} from '../../event/services/interfaces/changed-fields-map';
 import {TaskEventOutcome} from '../../event/model/event-outcomes/task-outcomes/task-event-outcome';
+import {FrontActionService} from "../../actions/services/front-action.service";
+import {FrontAction} from "../../data-fields/models/changed-fields";
 
 /**
  * Service that handles the logic of canceling a task.
@@ -45,6 +47,7 @@ export class CancelTaskService extends TaskHandlingService {
                 protected _eventQueue: EventQueueService,
                 protected _eventService: EventService,
                 protected _changedFieldsService: ChangedFieldsService,
+                protected _frontActionService: FrontActionService,
                 @Inject(NAE_TASK_OPERATIONS) protected _taskOperations: TaskOperations,
                 @Optional() _selectedCaseService: SelectedCaseService,
                 @Optional() protected _taskViewService: TaskViewService,
@@ -125,6 +128,10 @@ export class CancelTaskService extends TaskHandlingService {
                     .parseChangedFieldsFromOutcomeTree(outcomeResource.outcome);
                 if (!!changedFieldsMap) {
                     this._changedFieldsService.emitChangedFields(changedFieldsMap);
+                }
+                const frontActions: Array<FrontAction> = this._eventService.parseFrontActionsFromOutcomeTree(outcomeResource.outcome);
+                if (frontActions?.length > 0) {
+                    this._frontActionService.runAll(frontActions);
                 }
                 forceReload ? this._taskOperations.forceReload() : this._taskOperations.reload();
                 this.completeActions(afterAction, nextEvent, true, outcomeResource.outcome as CancelTaskEventOutcome);

--- a/projects/netgrif-components-core/src/lib/task/services/finish-task.service.ts
+++ b/projects/netgrif-components-core/src/lib/task/services/finish-task.service.ts
@@ -24,6 +24,8 @@ import {ChangedFieldsService} from '../../changed-fields/services/changed-fields
 import {EventService} from '../../event/services/event.service';
 import {ChangedFieldsMap} from '../../event/services/interfaces/changed-fields-map';
 import {TaskEventOutcome} from '../../event/model/event-outcomes/task-outcomes/task-event-outcome';
+import {FrontActionService} from '../../actions/services/front-action.service';
+import {FrontAction} from '../../data-fields/models/changed-fields';
 
 
 /**
@@ -43,6 +45,7 @@ export class FinishTaskService extends TaskHandlingService {
                 protected _eventQueue: EventQueueService,
                 protected _eventService: EventService,
                 protected _changedFieldsService: ChangedFieldsService,
+                protected _frontActionService: FrontActionService,
                 @Inject(NAE_TASK_OPERATIONS) protected _taskOperations: TaskOperations,
                 @Optional() _selectedCaseService: SelectedCaseService,
                 _taskContentService: TaskContentService) {
@@ -139,6 +142,10 @@ export class FinishTaskService extends TaskHandlingService {
                     .parseChangedFieldsFromOutcomeTree(outcomeResource.outcome);
                 if (!!changedFieldsMap) {
                     this._changedFieldsService.emitChangedFields(changedFieldsMap);
+                }
+                const frontActions: Array<FrontAction> = this._eventService.parseFrontActionsFromOutcomeTree(outcomeResource.outcome);
+                if (frontActions?.length > 0) {
+                    this._frontActionService.runAll(frontActions);
                 }
                 this._taskOperations.reload();
                 this.completeActions(afterAction, nextEvent, true, outcomeResource.outcome as FinishTaskEventOutcome);


### PR DESCRIPTION
# Description

Handle frontend actions on task events

Implements [ETASK-29]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

manually

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |  Ubuntu 24.04.1 LTS |
| Runtime             |  Node 23.6.1  |
| Dependency Manager  |   NPM 11.0.0  |
| Framework version   |    Angular 19.2.2  |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes have been checked, personally or remotely, with @...
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have resolved all conflicts with the target branch of the PR
- [ ] I have updated and synced my code with the target branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes:
    - [ ] Lint test
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_components)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
    - [ ] Developer documentation
    - [ ] User Guides
    - [ ] Migration Guides


[ETASK-29]: https://netgrif.atlassian.net/browse/ETASK-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task operations (assign, cancel, and finish) now execute additional actions returned by the system in response to those operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->